### PR TITLE
Adds a functional digit keypad and screen to VHF handheld

### DIFF
--- a/src/main/java/com/arrl/radiocraft/client/screens/radios/VHFHandheldScreen.java
+++ b/src/main/java/com/arrl/radiocraft/client/screens/radios/VHFHandheldScreen.java
@@ -4,10 +4,7 @@ import com.arrl.radiocraft.Radiocraft;
 import com.arrl.radiocraft.api.capabilities.IVHFHandheldCapability;
 import com.arrl.radiocraft.api.capabilities.RadiocraftCapabilities;
 import com.arrl.radiocraft.client.RadiocraftClientValues;
-import com.arrl.radiocraft.client.screens.widgets.Dial;
-import com.arrl.radiocraft.client.screens.widgets.HoldButton;
-import com.arrl.radiocraft.client.screens.widgets.ImageButton;
-import com.arrl.radiocraft.client.screens.widgets.ToggleButton;
+import com.arrl.radiocraft.client.screens.widgets.*;
 import com.arrl.radiocraft.common.init.RadiocraftPackets;
 import com.arrl.radiocraft.common.network.packets.serverbound.SHandheldFrequencyPacket;
 import com.arrl.radiocraft.common.network.packets.serverbound.SHandheldPTTPacket;
@@ -65,19 +62,19 @@ public class VHFHandheldScreen extends Screen {
         addRenderableWidget(new Dial(leftPos + 111, topPos - 1, 37, 21, 76, 42, WIDGETS_TEXTURE, 256, 256, this::doNothing, this::doNothing)); // Gain
         addRenderableWidget(new ImageButton(leftPos + 106, topPos + 168, 18, 14, 76, 84, WIDGETS_TEXTURE, 256, 256, this::onFrequencyButtonUp)); // Frequency up button
         addRenderableWidget(new ImageButton(leftPos + 126, topPos + 168, 18, 14, 76, 98, WIDGETS_TEXTURE, 256, 256, this::onFrequencyButtonDown)); // Frequency down button
-        addRenderableWidget(new ImageButton(leftPos + 31, topPos + 169, 18, 12, 172, 5, WIDGETS_TEXTURE, 256, 256, this::onPressOne)); // 1
-        addRenderableWidget(new ImageButton(leftPos + 56, topPos + 169, 18, 12, 172, 75, WIDGETS_TEXTURE, 256, 256, this::onPressTwo)); // 2
-        addRenderableWidget(new ImageButton(leftPos + 80, topPos + 169, 18, 12, 171, 146, WIDGETS_TEXTURE, 256, 256, this::onPressThree)); // 3
-        addRenderableWidget(new ImageButton(leftPos + 31, topPos + 188, 18, 12, 172, 24, WIDGETS_TEXTURE, 256, 256, this::onPressFour)); // 4
-        addRenderableWidget(new ImageButton(leftPos + 56, topPos + 188, 18, 12, 172, 94, WIDGETS_TEXTURE, 256, 256, this::onPressFive)); // 5
-        addRenderableWidget(new ImageButton(leftPos + 80, topPos + 188, 18, 12, 221, 106, WIDGETS_TEXTURE, 256, 256, this::onPressSix)); // 6
-        addRenderableWidget(new ImageButton(leftPos + 31, topPos + 207, 18, 12, 172, 43, WIDGETS_TEXTURE, 256, 256, this::onPressSeven)); // 7
-        addRenderableWidget(new ImageButton(leftPos + 56, topPos + 207, 18, 12, 172, 113, WIDGETS_TEXTURE, 256, 256, this::onPressEight)); // 8
-        addRenderableWidget(new ImageButton(leftPos + 80, topPos + 207, 18, 12, 221, 125, WIDGETS_TEXTURE, 256, 256, this::onPressNine)); // 9
-        addRenderableWidget(new ImageButton(leftPos + 31, topPos + 226, 18, 12, 172, 62, WIDGETS_TEXTURE, 256, 256, this::onPressStar)); // *
-        addRenderableWidget(new ImageButton(leftPos + 56, topPos + 226, 18, 12, 172, 132, WIDGETS_TEXTURE, 256, 256, this::onPressZero)); // 0
-        addRenderableWidget(new ImageButton(leftPos + 80, topPos + 226, 18, 12, 221, 144, WIDGETS_TEXTURE, 256, 256, this::onPressPound)); // #
-        addRenderableWidget(new ImageButton(leftPos + 104, topPos + 224, 40, 12, 193, 64, WIDGETS_TEXTURE, 256, 256, this::onPressEnter)); // Enter
+        addRenderableWidget(new PressedButton(leftPos + 31, topPos + 169, 18, 12, 172, 5, WIDGETS_TEXTURE, 256, 256, this::onPressOne)); // 1
+        addRenderableWidget(new PressedButton(leftPos + 56, topPos + 169, 18, 12, 172, 75, WIDGETS_TEXTURE, 256, 256, this::onPressTwo)); // 2
+        addRenderableWidget(new PressedButton(leftPos + 80, topPos + 169, 18, 12, 171, 146, WIDGETS_TEXTURE, 256, 256, this::onPressThree)); // 3
+        addRenderableWidget(new PressedButton(leftPos + 31, topPos + 188, 18, 12, 172, 24, WIDGETS_TEXTURE, 256, 256, this::onPressFour)); // 4
+        addRenderableWidget(new PressedButton(leftPos + 56, topPos + 188, 18, 12, 172, 94, WIDGETS_TEXTURE, 256, 256, this::onPressFive)); // 5
+        addRenderableWidget(new PressedButton(leftPos + 80, topPos + 188, 18, 12, 221, 106, WIDGETS_TEXTURE, 256, 256, this::onPressSix)); // 6
+        addRenderableWidget(new PressedButton(leftPos + 31, topPos + 207, 18, 12, 172, 43, WIDGETS_TEXTURE, 256, 256, this::onPressSeven)); // 7
+        addRenderableWidget(new PressedButton(leftPos + 56, topPos + 207, 18, 12, 172, 113, WIDGETS_TEXTURE, 256, 256, this::onPressEight)); // 8
+        addRenderableWidget(new PressedButton(leftPos + 80, topPos + 207, 18, 12, 221, 125, WIDGETS_TEXTURE, 256, 256, this::onPressNine)); // 9
+        addRenderableWidget(new PressedButton(leftPos + 31, topPos + 226, 18, 12, 172, 62, WIDGETS_TEXTURE, 256, 256, this::onPressStar)); // *
+        addRenderableWidget(new PressedButton(leftPos + 56, topPos + 226, 18, 12, 172, 132, WIDGETS_TEXTURE, 256, 256, this::onPressZero)); // 0
+        addRenderableWidget(new PressedButton(leftPos + 80, topPos + 226, 18, 12, 221, 144, WIDGETS_TEXTURE, 256, 256, this::onPressPound)); // #
+        addRenderableWidget(new PressedButton(leftPos + 104, topPos + 224, 40, 12, 193, 64, WIDGETS_TEXTURE, 256, 256, this::onPressEnter)); // Enter
     }
 
     @Override

--- a/src/main/java/com/arrl/radiocraft/client/screens/widgets/PressedButton.java
+++ b/src/main/java/com/arrl/radiocraft/client/screens/widgets/PressedButton.java
@@ -1,0 +1,74 @@
+package com.arrl.radiocraft.client.screens.widgets;
+
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.renderer.GameRenderer;
+import net.minecraft.network.chat.CommonComponents;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+
+public class PressedButton  extends Button {
+    private final ResourceLocation resourceLocation;
+    private final int u;
+    private final int v;
+    private final int textureWidth;
+    private final int textureHeight;
+    private boolean isHeld = false;
+
+    public PressedButton(int x, int y, int width, int height, int u, int v, ResourceLocation resourceLocation, int textureWidth, int textureHeight, Button.OnPress onPress) {
+        super(x, y, width, height, CommonComponents.EMPTY, onPress, DEFAULT_NARRATION);
+        this.resourceLocation = resourceLocation;
+        this.u = u;
+        this.v = v;
+        this.textureWidth = textureWidth;
+        this.textureHeight = textureHeight;
+    }
+
+    public void onClick(double pMouseX, double pMouseY) {
+        super.onClick(pMouseX, pMouseY);
+        // This reliably fires, even if the user proceeds to drag.
+        isHeld = true;
+    }
+
+    public void onRelease(double pMouseX, double pMouseY) {
+        super.onRelease(pMouseX, pMouseY);
+        // Note: this does not fire if the user drags, even for a pixel. Thus, the onDrag handler.
+        isHeld = false;
+    }
+
+    public void onDrag(double pMouseX, double pMouseY, double dragX, double dragY) {
+        super.onDrag(pMouseX, pMouseY, dragX, dragY);
+        /*
+        Checks if the mouse is still in the bounds of the button. If not, release the button.\
+        We only release it; onDrag can still re-enter the button which would show a re-press,
+        which the game doesn't actually process because it watches for when the click occurs.
+        (Until the mouse is released, the onDrag will be called back to here for any mouse movement over the whole GUI)
+         */
+        int left = getX();
+        int top = getY();
+        int right = getX() + getWidth();
+        int bottom = getY() + getHeight();
+        if (!(left <= pMouseX) || !(pMouseX <= right) || !(top <= pMouseY) || !(pMouseY <= bottom)) {
+            isHeld = false;
+        }
+    }
+
+    @Override
+    public void renderButton(PoseStack poseStack, int mouseX, int mouseY, float partialTick) {
+        // TL;DR When the button is held, render the pressed version, otherwise render the background.
+        if (isHeld) {
+            RenderSystem.setShader(GameRenderer::getPositionTexShader);
+            RenderSystem.setShaderTexture(0, this.resourceLocation);
+            RenderSystem.enableDepthTest();
+            blit(poseStack, getX(), getY(), u, v, width, height, textureWidth, textureHeight);
+        }
+    }
+
+    @OnlyIn(Dist.CLIENT)
+    public interface OnPress {
+        void onPress(Button pButton);
+    }
+
+}


### PR DESCRIPTION
This adds two features:

1. A screen that indicates the frequency
2. Digits and decimals on the keypad allow for entry of the frequency upon pressing Enter

When entering the frequency, it overrides the currently viewed frequency on-screen, and shows a `_` (or `#`) to indicate entry mode.

~This is a draft because the GUI messes up with the buttons because I need to make a better widget class that combines the features of ImageButton and HoldButton to make a button that only shows the alternative texture while the button is being pressed, and to show the default underlying texture otherwise.~

This PR is ready for review. I would say that the UI inconsistencies should be addressed, but I do not know if that fits the scope of this pull request.