### PR TITLE
Fix all band radio

### DIFF
--- a/src/main/java/com/arrl/radiocraft/CommonConfig.java
+++ b/src/main/java/com/arrl/radiocraft/CommonConfig.java
@@ -23,6 +23,8 @@ public class CommonConfig {
 	public static final ModConfigSpec.ConfigValue<Integer> HF_RADIO_40M_TRANSMIT_TICK;
 	public static final ModConfigSpec.ConfigValue<Integer> HF_RADIO_80M_RECEIVE_TICK;
 	public static final ModConfigSpec.ConfigValue<Integer> HF_RADIO_80M_TRANSMIT_TICK;
+	public static final ModConfigSpec.ConfigValue<Integer> HF_RADIO_ALL_BAND_TRANSMIT_TICK;
+	public static final ModConfigSpec.ConfigValue<Integer> HF_RADIO_ALL_BAND_RECEIVE_TICK;
 	public static final ModConfigSpec.ConfigValue<Integer> HF_RECEIVER_TICK;
 	public static final ModConfigSpec.ConfigValue<Integer> VHF_BASE_STATION_RECEIVE_TICK;
 	public static final ModConfigSpec.ConfigValue<Integer> VHF_BASE_STATION_TRANSMIT_TICK;
@@ -55,6 +57,8 @@ public class CommonConfig {
 		HF_RADIO_40M_TRANSMIT_TICK = BUILDER.comment("*HF Radio (40m) power consumption per tick (while transmitting) #default 375").define("hf_radio_40m_transmit", 375);
 		HF_RADIO_80M_RECEIVE_TICK = BUILDER.comment("*HF Radio (80m) power consumption per tick (while receiving) #default 125").define("hf_radio_80m_receive", 125);
 		HF_RADIO_80M_TRANSMIT_TICK = BUILDER.comment("*HF Radio (80m) power consumption per tick (while transmitting) #default 375").define("hf_radio_80m_transmit", 375);
+		HF_RADIO_ALL_BAND_RECEIVE_TICK = BUILDER.comment("*HF Radio (all band) power consumption per tick (while receiving) default #125").define("hf_radio_all_band_receive", 125);
+		HF_RADIO_ALL_BAND_TRANSMIT_TICK = BUILDER.comment("*HF Radio (all band) power consumption per tick (while transmitting) #default 375").define("hf_radio_all_band_transmit", 375);
 		HF_RECEIVER_TICK = BUILDER.comment("*HF Receiver power consumption per tick (while receiving) #default 125").define("hf_receiver", 125);
 		QRP_RADIO_20M_RECEIVE_TICK = BUILDER.comment("*QRP Radio (20m) power consumption per tick (while receiving) #default 63").define("qrp_radio_20m_receive", 63);
 		QRP_RADIO_20M_TRANSMIT_TICK = BUILDER.comment("*QRP Radio (20m) power consumption per tick (while transmitting) #default 188").define("qrp_radio_20m_transmit", 188);

--- a/src/main/java/com/arrl/radiocraft/client/events/ClientSetupEvents.java
+++ b/src/main/java/com/arrl/radiocraft/client/events/ClientSetupEvents.java
@@ -27,6 +27,7 @@ public class ClientSetupEvents {
 		event.register(RadiocraftMenuTypes.HF_RADIO_20M.get(), HFRadio20mScreen::new);
 		event.register(RadiocraftMenuTypes.HF_RADIO_40M.get(), HFRadio40mScreen::new);
 		event.register(RadiocraftMenuTypes.HF_RADIO_80M.get(), HFRadio80mScreen::new);
+		event.register(RadiocraftMenuTypes.HF_RADIO_ALL_BAND.get(), HFRadioAllBandScreen::new);
 		event.register(RadiocraftMenuTypes.QRP_RADIO_20M.get(), QRPRadio20mScreen::new);
 		event.register(RadiocraftMenuTypes.QRP_RADIO_40M.get(), QRPRadio40mScreen::new);
 		event.register(RadiocraftMenuTypes.VHF_BASE_STATION.get(), VHFBaseStationScreen::new);

--- a/src/main/java/com/arrl/radiocraft/client/screens/radios/HFRadioAllBandScreen.java
+++ b/src/main/java/com/arrl/radiocraft/client/screens/radios/HFRadioAllBandScreen.java
@@ -1,0 +1,76 @@
+package com.arrl.radiocraft.client.screens.radios;
+
+import com.arrl.radiocraft.Radiocraft;
+import com.arrl.radiocraft.client.screens.widgets.*;
+import com.arrl.radiocraft.common.menus.HFRadioAllBandMenu;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.entity.player.Inventory;
+
+/*
+ * TODO This class was copied from the 10m screen and is almost certainly wrong all over.
+ */
+public class HFRadioAllBandScreen extends HFRadioScreen<HFRadioAllBandMenu> {
+
+    public HFRadioAllBandScreen(HFRadioAllBandMenu menu, Inventory playerInventory, Component title) {
+        super(menu, playerInventory, title, Radiocraft.id("textures/gui/hf_radio_all_band.png"), Radiocraft.id("textures/gui/hf_radio_all_band_widgets.png"));
+
+        this.imageWidth = 250;
+        this.imageHeight = 147;
+    }
+
+    @Override
+    protected void init() {
+        super.init();
+        addRenderableWidget(new ToggleButton(menu.isPowered(), leftPos + 13, topPos + 14, 14, 17, 0, 0, widgetsTexture, 256, 256, this::onPressPower)); // Power button
+        addRenderableWidget(new ValueButton(leftPos + 197, topPos + 66, 34, 19, 0, 34, widgetsTexture, 256, 256, () -> menu.blockEntity.getCWEnabled(), this::onPressCW)); // CW Button
+        addRenderableWidget(new ValueButton(leftPos + 197, topPos + 86, 34, 19, 0, 72, widgetsTexture, 256, 256, () -> menu.blockEntity.getSSBEnabled(), this::onPressSSB)); // SSB button
+        addRenderableWidget(new HoldButton(leftPos + 128, topPos + 110, 51, 19, 0, 110, widgetsTexture, 256, 256, this::onPressPTT, this::onReleasePTT)); // PTT button
+        addRenderableWidget(new Dial(leftPos + 134, topPos + 37, 42, 45, 102, 0, widgetsTexture, 256, 256, this::onFrequencyDialUp, this::onFrequencyDialDown)); // Frequency dial
+        addRenderableWidget(new ImageButton(leftPos + 129, topPos + 93, 25, 17, 0, 148, widgetsTexture, 256, 256, this::onFrequencyButtonUp)); // Frequency up button
+        addRenderableWidget(new ImageButton(leftPos + 154, topPos + 93, 25, 17, 0, 182, widgetsTexture, 256, 256, this::onFrequencyButtonDown)); // Frequency down button
+        addRenderableWidget(new Dial(leftPos + 209, topPos + 20, 32, 34, 102, 90, widgetsTexture, 256, 256, this::doNothing, this::doNothing)); // Gain dial
+        addRenderableWidget(new Dial(leftPos + 90, topPos + 86, 32, 34, 102, 90, widgetsTexture, 256, 256, this::doNothing, this::doNothing)); // Mic gain dial
+    }
+
+    @Override
+    protected void renderBg(GuiGraphics pGuiGraphics, float pPartialTick, int pMouseX, int pMouseY) {
+
+    }
+
+    @Override
+    protected void renderAdditionalTooltips(GuiGraphics pGuiGraphics, int pMouseX, int pMouseY, float pPartialTick) {
+		/*
+		if(isHovering(33, 18, 25, 11, pMouseX, pMouseY))
+			renderTooltip(poseStack, Component.translatable(Radiocraft.translationKey("screen", "radio.tx")), pMouseX, pMouseY);
+		if(isHovering(62, 18, 25, 11, pMouseX, pMouseY))
+			renderTooltip(poseStack, Component.translatable(Radiocraft.translationKey("screen", "radio.rx")), pMouseX, pMouseY);
+
+		if(menu.isPowered()) {
+			poseStack.pushPose(); // Push/pop allows you to add a set of transformations to the stack. Pushing starts a new set and popping reverts to the previous set.
+
+			poseStack.scale(1.5F, 1.5F, 1.5F);
+			float freqMhz = menu.getFrequency() / 1000.0F; // Frequency is in kHz, divide by 1000 to get MHz
+			font.draw(poseStack, String.format("%.3f", freqMhz) + "MHz", (leftPos + 24) / 1.5F, (topPos + 50) / 1.5F, 0xFFFFFF); // Divide the positions rendered at by 1.5F as the entire pose was scaled by 1.5F.
+
+			poseStack.popPose(); // Reset pose stack. Will cause a memory leak if you push without popping.
+		}*/
+    }
+
+    @Override
+    protected void renderAdditionalBackground(GuiGraphics pGuiGraphics, int pMouseX, int pMouseY, float pPartialTick) {
+        if(menu.isPowered()) {
+//			if(menu.blockEntity.isTransmitting())
+//				blit(poseStack, leftPos + 30, topPos + 15, 1, 148, 29, 15);
+//			if(menu.blockEntity.isReceiving())
+//				blit(poseStack, leftPos + 59, topPos + 15, 30, 148, 29, 15);
+        }
+    }
+
+    protected boolean isHovering(int x, int y, int width, int height, double mouseX, double mouseY) {
+        mouseX -= leftPos;
+        mouseY -= topPos;
+        return mouseX >= (x - 1) && mouseX < (x + width + 1) && mouseY >= (y - 1) && mouseY < (y + height + 1);
+    }
+
+}

--- a/src/main/java/com/arrl/radiocraft/common/blockentities/radio/HFRadioAllBandBlockEntity.java
+++ b/src/main/java/com/arrl/radiocraft/common/blockentities/radio/HFRadioAllBandBlockEntity.java
@@ -1,0 +1,39 @@
+package com.arrl.radiocraft.common.blockentities.radio;
+
+import com.arrl.radiocraft.CommonConfig;
+import com.arrl.radiocraft.api.benetworks.BENetworkObject;
+import com.arrl.radiocraft.common.be_networks.network_objects.RadioNetworkObject;
+import com.arrl.radiocraft.common.init.RadiocraftBlockEntities;
+import com.arrl.radiocraft.common.menus.HFRadioAllBandMenu;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.level.block.state.BlockState;
+import org.jetbrains.annotations.Nullable;
+
+public class HFRadioAllBandBlockEntity extends HFRadioBlockEntity {
+
+    public HFRadioAllBandBlockEntity(BlockPos pos, BlockState state) {
+        super(RadiocraftBlockEntities.HF_RADIO_ALL_BAND.get(), pos, state, 10);
+    }
+
+    @Override
+    public Component getDisplayName() {
+        return Component.translatable("container.hf_radio_all_band");
+    }
+
+    @Nullable
+    @Override
+    public AbstractContainerMenu createMenu(int id, Inventory playerInventory, Player player) {
+        return new HFRadioAllBandMenu(id, this);
+    }
+
+    @Override
+    public BENetworkObject createNetworkObject() {
+        return new RadioNetworkObject(level, worldPosition, CommonConfig.HF_RADIO_ALL_BAND_TRANSMIT_TICK.get(), CommonConfig.HF_RADIO_ALL_BAND_RECEIVE_TICK.get());
+    }
+
+}
+

--- a/src/main/java/com/arrl/radiocraft/common/blocks/HFRadioAllBandBlock.java
+++ b/src/main/java/com/arrl/radiocraft/common/blocks/HFRadioAllBandBlock.java
@@ -1,0 +1,50 @@
+package com.arrl.radiocraft.common.blocks;
+
+import com.arrl.radiocraft.common.blockentities.radio.HFRadio10mBlockEntity;
+import com.arrl.radiocraft.common.blockentities.radio.HFRadioAllBandBlockEntity;
+import com.mojang.serialization.MapCodec;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.block.BaseEntityBlock;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.shapes.CollisionContext;
+import net.minecraft.world.phys.shapes.VoxelShape;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.HashMap;
+
+public class HFRadioAllBandBlock extends RadioBlock {
+
+    public static final HashMap<Direction, VoxelShape> SHAPES = new HashMap<>();
+
+    static {
+        SHAPES.put(Direction.NORTH, Block.box(1.0D, 0.0D, 3.0D, 15.0D, 5.0D, 16.0D));
+        SHAPES.put(Direction.SOUTH, Block.box(1.0D, 0.0D, 0.0D, 15.0D, 5.0D, 13.0D));
+        SHAPES.put(Direction.WEST, Block.box(3.0D, 0.0D, 1.0D, 16.0D, 5.0D, 15.0D));
+        SHAPES.put(Direction.EAST, Block.box(0.0D, 0.0D, 1.0D, 13.0D, 5.0D, 15.0D));
+    }
+
+    public HFRadioAllBandBlock(Properties properties) {
+        super(properties);
+    }
+
+    @Override
+    protected MapCodec<? extends BaseEntityBlock> codec() {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public BlockEntity newBlockEntity(BlockPos pos, BlockState state) {
+        return new HFRadioAllBandBlockEntity(pos, state);
+    }
+
+    @Override
+    public VoxelShape getShape(BlockState state, BlockGetter level, BlockPos pos, CollisionContext context) {
+        return SHAPES.get(state.getValue(RadioBlock.HORIZONTAL_FACING));
+    }
+
+}

--- a/src/main/java/com/arrl/radiocraft/common/init/RadiocraftBlockEntities.java
+++ b/src/main/java/com/arrl/radiocraft/common/init/RadiocraftBlockEntities.java
@@ -30,6 +30,8 @@ public class RadiocraftBlockEntities {
 			() -> BlockEntityType.Builder.of(HFRadio40mBlockEntity::new, RadiocraftBlocks.HF_RADIO_40M.get()).build(null));
 	public static final Supplier<BlockEntityType<HFRadio80mBlockEntity>> HF_RADIO_80M = BLOCK_ENTITY_TYPES.register("hf_radio_80m",
 			() -> BlockEntityType.Builder.of(HFRadio80mBlockEntity::new, RadiocraftBlocks.HF_RADIO_80M.get()).build(null));
+	public static final Supplier<BlockEntityType<HFRadioAllBandBlockEntity>> HF_RADIO_ALL_BAND = BLOCK_ENTITY_TYPES.register("all_band_radio",
+			() -> BlockEntityType.Builder.of(HFRadioAllBandBlockEntity::new, RadiocraftBlocks.ALL_BAND_RADIO.get()).build(null));
 	public static final Supplier<BlockEntityType<HFReceiverBlockEntity>> HF_RECEIVER = BLOCK_ENTITY_TYPES.register("hf_receiver",
 			() -> BlockEntityType.Builder.of(HFReceiverBlockEntity::new, RadiocraftBlocks.HF_RECEIVER.get()).build(null));
 	public static final Supplier<BlockEntityType<QRPRadio20mBlockEntity>> QRP_RADIO_20M = BLOCK_ENTITY_TYPES.register("qrp_radio_20m",

--- a/src/main/java/com/arrl/radiocraft/common/init/RadiocraftBlocks.java
+++ b/src/main/java/com/arrl/radiocraft/common/init/RadiocraftBlocks.java
@@ -43,7 +43,7 @@ public class RadiocraftBlocks {
 	public static final DeferredHolder<Block, HFRadio80mBlock> HF_RADIO_80M = BLOCKS.register("hf_radio_80m", () -> new HFRadio80mBlock(PROPERTIES_RADIO));
 	public static final DeferredHolder<Block, HFReceiverBlock> HF_RECEIVER = BLOCKS.register("hf_receiver", () -> new HFReceiverBlock(PROPERTIES_RADIO));
 
-	public static final Supplier<Block> ALL_BAND_RADIO = simpleBlock("all_band_radio", PROPERTIES_STONE);
+	public static final DeferredHolder<Block, HFRadioAllBandBlock> ALL_BAND_RADIO = BLOCKS.register("all_band_radio", () -> new HFRadioAllBandBlock(PROPERTIES_RADIO));
 	public static final DeferredHolder<Block, QRPRadio20mBlock> QRP_RADIO_20M = BLOCKS.register("qrp_radio_20m", () -> new QRPRadio20mBlock(PROPERTIES_RADIO));
 	public static final DeferredHolder<Block, QRPRadio40mBlock> QRP_RADIO_40M = BLOCKS.register("qrp_radio_40m", () -> new QRPRadio40mBlock(PROPERTIES_RADIO));
 	public static final DeferredHolder<Block, DigitalInterfaceBlock> DIGITAL_INTERFACE = BLOCKS.register("digital_interface", () -> new DigitalInterfaceBlock(PROPERTIES_STONE));

--- a/src/main/java/com/arrl/radiocraft/common/init/RadiocraftMenuTypes.java
+++ b/src/main/java/com/arrl/radiocraft/common/init/RadiocraftMenuTypes.java
@@ -21,6 +21,7 @@ public class RadiocraftMenuTypes {
 	public static final Supplier<MenuType<HFRadio20mMenu>> HF_RADIO_20M = MENU_TYPES.register("hf_radio_20m", () -> IMenuTypeExtension.create(HFRadio20mMenu::new));
 	public static final Supplier<MenuType<HFRadio40mMenu>> HF_RADIO_40M = MENU_TYPES.register("hf_radio_40m", () -> IMenuTypeExtension.create(HFRadio40mMenu::new));
 	public static final Supplier<MenuType<HFRadio80mMenu>> HF_RADIO_80M = MENU_TYPES.register("hf_radio_80m", () -> IMenuTypeExtension.create(HFRadio80mMenu::new));
+	public static final Supplier<MenuType<HFRadioAllBandMenu>> HF_RADIO_ALL_BAND = MENU_TYPES.register("hf_radio_all_band", () -> IMenuTypeExtension.create(HFRadioAllBandMenu::new));
 	public static final Supplier<MenuType<HFReceiverMenu>> HF_RECEIVER = MENU_TYPES.register("hf_receiver", () -> IMenuTypeExtension.create(HFReceiverMenu::new));
 	public static final Supplier<MenuType<QRPRadio20mMenu>> QRP_RADIO_20M = MENU_TYPES.register("qrp_radio_20m", () -> IMenuTypeExtension.create(QRPRadio20mMenu::new));
 	public static final Supplier<MenuType<QRPRadio40mMenu>> QRP_RADIO_40M = MENU_TYPES.register("qrp_radio_40m", () -> IMenuTypeExtension.create(QRPRadio40mMenu::new));

--- a/src/main/java/com/arrl/radiocraft/common/menus/HFRadioAllBandMenu.java
+++ b/src/main/java/com/arrl/radiocraft/common/menus/HFRadioAllBandMenu.java
@@ -1,0 +1,20 @@
+package com.arrl.radiocraft.common.menus;
+
+import com.arrl.radiocraft.common.blockentities.radio.HFRadio10mBlockEntity;
+import com.arrl.radiocraft.common.blockentities.radio.HFRadioAllBandBlockEntity;
+import com.arrl.radiocraft.common.init.RadiocraftBlocks;
+import com.arrl.radiocraft.common.init.RadiocraftMenuTypes;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.world.entity.player.Inventory;
+
+public class HFRadioAllBandMenu  extends RadioMenu<HFRadioAllBandBlockEntity> {
+
+    public HFRadioAllBandMenu(int id, HFRadioAllBandBlockEntity blockEntity) {
+        super(RadiocraftMenuTypes.HF_RADIO_ALL_BAND.get(), id, blockEntity, RadiocraftBlocks.ALL_BAND_RADIO.get());
+    }
+
+    public HFRadioAllBandMenu(final int id, final Inventory playerInventory, final FriendlyByteBuf data) { // Clientside constructor doesn't need a RadioNetworkObject
+        this(id, MenuUtils.getBlockEntity(playerInventory, data, HFRadioAllBandBlockEntity.class));
+    }
+
+}


### PR DESCRIPTION
This obviously gets merged after the port code.

Fixes the all band radio rendering issue by properly implementing the block which results in the block render type being set correctly (it was being rendered as though it was a solid block and not a model, which enabled the face to be culled from the render for the block below it).

It also has the side effect of adding a bunch of the backend code for the Menu, Screen, Block, Block Entity, and some registration items that needed to be done. Also added to the config.