### PR TITLE
Feature/hide unimplemented

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,11 +35,13 @@ neoForge {
         }
 
         create("client") {
+            environment("RADIOCRAFT_DEV_ENV", "true")
             client()
             gameDirectory = file("runs/client")
         }
 
         create("server") {
+            environment("RADIOCRAFT_DEV_ENV", "true")
             server()
             gameDirectory = file("runs/server")
             programArgument("--nogui")

--- a/src/main/java/com/arrl/radiocraft/Radiocraft.java
+++ b/src/main/java/com/arrl/radiocraft/Radiocraft.java
@@ -9,11 +9,9 @@ import net.minecraft.data.DataGenerator;
 import net.minecraft.data.DataProvider.Factory;
 import net.minecraft.resources.ResourceLocation;
 import net.neoforged.bus.api.IEventBus;
-import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.ModLoadingContext;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.fml.config.ModConfig;
-import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.common.data.ExistingFileHelper;
 import net.neoforged.neoforge.data.event.GatherDataEvent;
 import org.slf4j.Logger;
@@ -26,6 +24,7 @@ public class Radiocraft {
     public static final String MOD_ID = "radiocraft";
     public static final Logger LOGGER = LogUtils.getLogger();
     public static final Random RANDOM = new Random();
+    public static final boolean IS_DEVELOPMENT_ENV = System.getenv("RADIOCRAFT_DEV_ENV") != null;
 
     public Radiocraft() {
         registerRegistries();
@@ -33,7 +32,6 @@ public class Radiocraft {
 
         ModLoadingContext.get().getActiveContainer().registerConfig(ModConfig.Type.COMMON, CommonConfig.SPEC, Radiocraft.MOD_ID + "-common.toml");
         ModLoadingContext.get().getActiveContainer().registerConfig(ModConfig.Type.SERVER, RadiocraftServerConfig.SPEC, Radiocraft.MOD_ID + "-server.toml");
-        //NeoForge.EVENT_BUS.register(this);
     }
 
     // Registering deferred registries to the event bus
@@ -50,7 +48,6 @@ public class Radiocraft {
         RadiocraftMenuTypes.MENU_TYPES.register(modEventBus);
         RadiocraftSoundEvents.SOUND_EVENTS.register(modEventBus);
         RadiocraftTabs.CREATIVE_TABS.register(modEventBus);
-        //RadiocraftPackets.registerPackets();
 
         modEventBus.addListener(Radiocraft::gatherData);
     }

--- a/src/main/java/com/arrl/radiocraft/common/init/RadiocraftTabs.java
+++ b/src/main/java/com/arrl/radiocraft/common/init/RadiocraftTabs.java
@@ -4,13 +4,11 @@ import com.arrl.radiocraft.Radiocraft;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.CreativeModeTab;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.block.Block;
-import net.neoforged.bus.api.SubscribeEvent;
-import net.neoforged.fml.common.EventBusSubscriber;
-import net.neoforged.neoforge.event.BuildCreativeModeTabContentsEvent;
 import net.neoforged.neoforge.registries.DeferredRegister;
 
+import java.util.ArrayList;
 import java.util.function.Supplier;
 
 /**
@@ -20,46 +18,58 @@ public class RadiocraftTabs {
 
     public static final DeferredRegister<CreativeModeTab> CREATIVE_TABS = DeferredRegister.create(BuiltInRegistries.CREATIVE_MODE_TAB, Radiocraft.MOD_ID);
 
+
     public static CreativeModeTab TAB = CreativeModeTab.builder().icon(() -> new ItemStack(RadiocraftItems.HF_RADIO_10M.get())).title(Component.translatable(Radiocraft.translationKey("tabs", "main_tab"))).displayItems((itemDisplayParameters, output) -> {
+
+        // In the development environment, we load everything.
+        // In the release version, we only enabled working items/blocks. So put all stuff not ready for release here.
+        if (Radiocraft.IS_DEVELOPMENT_ENV) {
+            output.accept(RadiocraftItems.HAND_MICROPHONE.get());
+            output.accept(RadiocraftItems.HF_CIRCUIT_BOARD.get());
+            output.accept(RadiocraftItems.SMALL_BATTERY.get());
+            output.accept(RadiocraftItems.FERRITE_CORE.get());
+            output.accept(RadiocraftItems.COAXIAL_CORE.get());
+            output.accept(RadiocraftItems.ANTENNA_ANALYZER.get());
+            output.accept(RadiocraftItems.WATERPROOF_WIRE.get());
+            output.accept(RadiocraftItems.SOLAR_PANEL.get());
+            output.accept(RadiocraftItems.LARGE_BATTERY.get());
+            output.accept(RadiocraftItems.CHARGE_CONTROLLER.get());
+            output.accept(RadiocraftItems.SOLAR_WEATHER_STATION.get());
+            output.accept(RadiocraftItems.VHF_BASE_STATION.get());
+            output.accept(RadiocraftItems.VHF_RECEIVER.get());
+            output.accept(RadiocraftItems.VHF_REPEATER.get());
+            output.accept(RadiocraftItems.HF_RADIO_10M.get());
+            output.accept(RadiocraftItems.HF_RADIO_20M.get());
+            output.accept(RadiocraftItems.HF_RADIO_40M.get());
+            output.accept(RadiocraftItems.HF_RADIO_80M.get());
+            output.accept(RadiocraftItems.HF_RECEIVER.get());
+            output.accept(RadiocraftItems.ALL_BAND_RADIO.get());
+            output.accept(RadiocraftItems.QRP_RADIO_20M.get());
+            output.accept(RadiocraftItems.QRP_RADIO_40M.get());
+            output.accept(RadiocraftItems.ANTENNA_POLE.get());
+            output.accept(RadiocraftItems.DUPLEXER.get());
+            output.accept(RadiocraftItems.ANTENNA_TUNER.get());
+            output.accept(RadiocraftItems.ANTENNA_WIRE.get());
+            output.accept(RadiocraftItems.ANTENNA_CONNECTOR.get());
+            output.accept(RadiocraftItems.BALUN_ONE_TO_ONE.get());
+            output.accept(RadiocraftItems.BALUN_TWO_TO_ONE.get());
+            output.accept(RadiocraftItems.COAX_WIRE.get());
+            output.accept(RadiocraftItems.DIGITAL_INTERFACE.get());
+            output.accept(RadiocraftItems.YAGI_ANTENNA.get());
+            output.accept(RadiocraftItems.J_POLE_ANTENNA.get());
+            output.accept(RadiocraftItems.SLIM_JIM_ANTENNA.get());
+        }
+
+        // Anything below here should be in the release creative menu
+
+        // Crafting ingredients for VHF Handheld (the only actual working radio right now)
         output.accept(RadiocraftItems.RADIO_CRYSTAL.get());
         output.accept(RadiocraftItems.RADIO_SPEAKER.get());
         output.accept(RadiocraftItems.MICROPHONE.get());
-        output.accept(RadiocraftItems.HAND_MICROPHONE.get());
-        output.accept(RadiocraftItems.HF_CIRCUIT_BOARD.get());
-        output.accept(RadiocraftItems.SMALL_BATTERY.get());
-        output.accept(RadiocraftItems.FERRITE_CORE.get());
-        output.accept(RadiocraftItems.COAXIAL_CORE.get());
-        output.accept(RadiocraftItems.ANTENNA_ANALYZER.get());
         output.accept(RadiocraftItems.WIRE.get());
-        output.accept(RadiocraftItems.WATERPROOF_WIRE.get());
+
         output.accept(RadiocraftItems.VHF_HANDHELD.get());
-        output.accept(RadiocraftItems.SOLAR_PANEL.get());
-        output.accept(RadiocraftItems.LARGE_BATTERY.get());
-        output.accept(RadiocraftItems.CHARGE_CONTROLLER.get());
-        output.accept(RadiocraftItems.SOLAR_WEATHER_STATION.get());
-        output.accept(RadiocraftItems.VHF_BASE_STATION.get());
-        output.accept(RadiocraftItems.VHF_RECEIVER.get());
-        output.accept(RadiocraftItems.VHF_REPEATER.get());
-        output.accept(RadiocraftItems.HF_RADIO_10M.get());
-        output.accept(RadiocraftItems.HF_RADIO_20M.get());
-        output.accept(RadiocraftItems.HF_RADIO_40M.get());
-        output.accept(RadiocraftItems.HF_RADIO_80M.get());
-        output.accept(RadiocraftItems.HF_RECEIVER.get());
-        output.accept(RadiocraftItems.ALL_BAND_RADIO.get());
-        output.accept(RadiocraftItems.QRP_RADIO_20M.get());
-        output.accept(RadiocraftItems.QRP_RADIO_40M.get());
-        output.accept(RadiocraftItems.ANTENNA_POLE.get());
-        output.accept(RadiocraftItems.DUPLEXER.get());
-        output.accept(RadiocraftItems.ANTENNA_TUNER.get());
-        output.accept(RadiocraftItems.ANTENNA_WIRE.get());
-        output.accept(RadiocraftItems.ANTENNA_CONNECTOR.get());
-        output.accept(RadiocraftItems.BALUN_ONE_TO_ONE.get());
-        output.accept(RadiocraftItems.BALUN_TWO_TO_ONE.get());
-        output.accept(RadiocraftItems.COAX_WIRE.get());
-        output.accept(RadiocraftItems.DIGITAL_INTERFACE.get());
-        output.accept(RadiocraftItems.YAGI_ANTENNA.get());
-        output.accept(RadiocraftItems.J_POLE_ANTENNA.get());
-        output.accept(RadiocraftItems.SLIM_JIM_ANTENNA.get());
+
     }).build();
 
     public static Supplier<CreativeModeTab> RADIOCRAFT_TAB = CREATIVE_TABS.register("radiocraft_tabs", () -> TAB);


### PR DESCRIPTION
Two changes are made here:

**Add RADIOCRAFT_DEV_ENV env variable**

This change adds a new environmental variable to the Gradle task for client and server runs that indicates whether you are running in our development environment. You can query this by checking the static variable `Radiocraft.IS_DEVELOPMENT_ENV`.

**Hide unimplemented items and blocks**

This change hides unimplemented things when you are not in a development environment. We do this by hiding the items in the creative tab. We could also disable their crafting, but that's a bit more involved and not completely necessary.