### PR TITLE
Converted all console output to parameterized logger calls

### DIFF
--- a/src/main/java/com/arrl/radiocraft/api/antenna/AntennaTypes.java
+++ b/src/main/java/com/arrl/radiocraft/api/antenna/AntennaTypes.java
@@ -24,7 +24,7 @@ public class AntennaTypes {
 	public static <C extends IAntennaType<?>> C registerType(C type) {
 		ResourceLocation id = type.getId();
 		if(REGISTRY.containsKey(id))
-			Radiocraft.LOGGER.warn("Attempted to register a duplicate Antenna Type of ID " + id.toString());
+            Radiocraft.LOGGER.warn("Attempted to register a duplicate Antenna Type of ID {}", id.toString());
 		else
 			REGISTRY.put(id, type);
 

--- a/src/main/java/com/arrl/radiocraft/common/network/Serverbound/SHandheldRadioUpdatePacket.java
+++ b/src/main/java/com/arrl/radiocraft/common/network/Serverbound/SHandheldRadioUpdatePacket.java
@@ -68,14 +68,14 @@ public class SHandheldRadioUpdatePacket implements CustomPacketPayload {
             ItemStack stack = context.player().getInventory().getItem(this.index);
 
             if(stack == null){
-                System.err.println("Handheld Radio stack is null for player " + context.player().getName() + " despite getting handheld radio update packet"); //TODO replace with proper logging call
+                Radiocraft.LOGGER.error("Handheld Radio stack is null for player {} despite getting handheld radio update packet", context.player().getName());
                 return;
             }
 
             IVHFHandheldCapability cap = stack.getCapability(RadiocraftCapabilities.VHF_HANDHELDS);
 
             if(cap == null){
-                System.err.println("held item does not have handheld radio capability yet the following player send handheld radio update packet: " + context.player().getName()); //TODO replace with proper logging call
+                Radiocraft.LOGGER.error("held item does not have handheld radio capability yet the following player send handheld radio update packet: {}", context.player().getName());
                 return;
             }
 

--- a/src/main/java/com/arrl/radiocraft/common/radio/antenna/networks/AntennaNetworkManager.java
+++ b/src/main/java/com/arrl/radiocraft/common/radio/antenna/networks/AntennaNetworkManager.java
@@ -48,7 +48,7 @@ public class AntennaNetworkManager {
 		}
 		return null;*/
 		if(level == null){  //TODO remove this at some point
-			System.err.println("level is null, it's not currently required but interesting regardless, network was " + id.getPath());
+            Radiocraft.LOGGER.error("level is null, it's not currently required but interesting regardless, network was {}", id.getPath());
 			Thread.dumpStack();
 		}
 		return networks.get(id);

--- a/src/main/java/com/arrl/radiocraft/common/radio/solar/SolarEventManager.java
+++ b/src/main/java/com/arrl/radiocraft/common/radio/solar/SolarEventManager.java
@@ -45,9 +45,8 @@ public class SolarEventManager {
 					solarEvent = RadiocraftData.SOLAR_EVENTS.getWeightedRandom().getInstance(); // Keep picking new event if the current one is finished
 					setEvent(event.getLevel(), solarEvent);
 					//RadiocraftPackets.sendToLevel(new CNoisePacket(solarEvent.getEvent().getNoise()), (ServerLevel)event.getLevel()); // Update noise value for all players in that level
-					Radiocraft.LOGGER.info(event.getLevel().dimension() + " " + solarEvent.getEvent().getNoise());
+                    Radiocraft.LOGGER.info("Dimension: {} Solar Event Noise: {}", event.getLevel().dimension(), solarEvent.getEvent().getNoise());
 				}
-
 				solarEvent.tick();
 			//}
 		}

--- a/src/main/java/com/arrl/radiocraft/common/radio/voice/handheld/PlayerRadio.java
+++ b/src/main/java/com/arrl/radiocraft/common/radio/voice/handheld/PlayerRadio.java
@@ -53,8 +53,6 @@ public class PlayerRadio implements IVoiceTransmitter, IVoiceReceiver, IAntenna 
     public void setPlayer(Player player) {
 
         Player old = playerRef == null ? null : playerRef.get();
-        Radiocraft.LOGGER.error("Setting new player {}, old player was {}", player == null ? null : player.getName(), old == null ? (playerRef != null ? "already cleared" : "never set?") : old.getName());
-
         playerRef = new WeakReference<>(player);
         if(receiveChannel != null) {
             if (player != null){

--- a/src/main/java/com/arrl/radiocraft/common/radio/voice/handheld/PlayerRadio.java
+++ b/src/main/java/com/arrl/radiocraft/common/radio/voice/handheld/PlayerRadio.java
@@ -53,7 +53,7 @@ public class PlayerRadio implements IVoiceTransmitter, IVoiceReceiver, IAntenna 
     public void setPlayer(Player player) {
 
         Player old = playerRef == null ? null : playerRef.get();
-        System.err.println("Setting new player " + (player == null ? null : player.getName()) + ", old player was " + (old == null ? (playerRef != null ? "already cleared":"never set?") : old.getName()));
+        Radiocraft.LOGGER.error("Setting new player {}, old player was {}", player == null ? null : player.getName(), old == null ? (playerRef != null ? "already cleared" : "never set?") : old.getName());
 
         playerRef = new WeakReference<>(player);
         if(receiveChannel != null) {
@@ -152,7 +152,7 @@ public class PlayerRadio implements IVoiceTransmitter, IVoiceReceiver, IAntenna 
 
     public boolean openChannel() {
         if(RadiocraftVoicePlugin.API == null)
-            Radiocraft.LOGGER.error("VoiceChatServerApi has.");
+            Radiocraft.LOGGER.error("VoiceChatServerApi is null, cannot open channel.");
 //        receiveChannel = RadiocraftVoicePlugin.API.createEntityAudioChannel(UUID.randomUUID(), RadiocraftVoicePlugin.API.fromEntity(getPlayer()));
         currentlevel = getPlayer().level();
         receiveChannel = RadiocraftVoicePlugin.API.createLocationalAudioChannel(UUID.randomUUID(), RadiocraftVoicePlugin.API.fromServerLevel(currentlevel), getPosInVoiceApiFormat());

--- a/src/main/java/com/arrl/radiocraft/common/radio/voice/handheld/PlayerRadioManager.java
+++ b/src/main/java/com/arrl/radiocraft/common/radio/voice/handheld/PlayerRadioManager.java
@@ -23,14 +23,14 @@ public class PlayerRadioManager {
     public static void onPlayerJoined(PlayerEvent.PlayerLoggedInEvent event) {
         Player player = event.getEntity();
         playerRadios.put(player.getUUID(), new PlayerRadio(player));
-        Radiocraft.LOGGER.debug("Player radio added for " + player.getName() + " uuid " + player.getUUID());
+        Radiocraft.LOGGER.debug("Player radio added for {} uuid {}", player.getName(), player.getUUID());
     }
 
     @SubscribeEvent
     public static void onPlayerLeft(PlayerEvent.PlayerLoggedOutEvent event) {
         UUID uuid = event.getEntity().getUUID();
-        get(uuid).ifPresentOrElse(u -> u.setPlayer(null), () -> System.out.println("Player radio was null on leave, onPlayerJoined not called? Player: " + event.getEntity().getName() + " uuid " + event.getEntity().getUUID()));
-        Radiocraft.LOGGER.debug("Player radio added for " + event.getEntity().getName() + " uuid " + event.getEntity().getUUID());
+        get(uuid).ifPresentOrElse(u -> u.setPlayer(null), () -> Radiocraft.LOGGER.error("Player radio was null on leave, onPlayerJoined not called? Player: {} uuid {}", event.getEntity().getName(), event.getEntity().getUUID()));
+        Radiocraft.LOGGER.debug("Player radio removed for {} uuid {}", event.getEntity().getName(), event.getEntity().getUUID());
         playerRadios.remove(uuid);
     }
 
@@ -41,7 +41,7 @@ public class PlayerRadioManager {
                     r -> r.setPlayer(event.getEntity()),
                     () -> {
                         playerRadios.put(event.getEntity().getUUID(), new PlayerRadio(event.getEntity()));
-                        System.out.println("Player radio was null on death, onPlayerJoined not called? Player: " + event.getEntity().getName());
+                        Radiocraft.LOGGER.error("Player radio was null on death, onPlayerJoined not called? Player: {}", event.getEntity().getName());
                     }
             ); // Ensure to update the player object when cloned (e.g. dimension change)
         }


### PR DESCRIPTION
Cleans up the usage of `System.out.*` and `System.err.*` and replaces with the logger instance.

Parameterized calls are used for clarity.