### PR TITLE
Implements Antenna Collision Hitboxes

### DIFF
--- a/src/main/java/com/arrl/radiocraft/common/blocks/AbstractNetworkBlock.java
+++ b/src/main/java/com/arrl/radiocraft/common/blocks/AbstractNetworkBlock.java
@@ -9,10 +9,13 @@ import com.arrl.radiocraft.common.be_networks.ICoaxNetworkObject;
 import com.arrl.radiocraft.common.be_networks.WireUtils;
 import com.arrl.radiocraft.common.init.RadiocraftBlocks;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.BaseEntityBlock;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.RenderShape;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.shapes.VoxelShape;
 import org.jetbrains.annotations.NotNull;
 
 public abstract class AbstractNetworkBlock extends BaseEntityBlock {
@@ -60,4 +63,85 @@ public abstract class AbstractNetworkBlock extends BaseEntityBlock {
 		return RenderShape.MODEL;
 	}
 
+	/*
+	 * Note about the code below -
+	 * VoxelShape contains functionality for rotating the shape based on the direction of the block.
+	 * Unfortunately, their implementation in both VoxelShape and Shapes culls sides that don't touch a face. :(
+	 * The below code was written by Claude 4 Sonnet, so if there's an error, that might be why.
+	 */
+
+	private double[] getShapeDimensions(@NotNull VoxelShape shape) {
+		var boxes = shape.toAabbs().getFirst();
+		return new double[]{
+				boxes.minX * 16, boxes.minZ * 16,
+				boxes.maxX * 16, boxes.maxZ * 16
+		};
+	}
+
+	/**
+	 * Rotates the given voxel shape on the horizontal plane from the model direction to the target direction.
+	 *
+	 * @param modelDirection the {@link Direction} that the base shape is currently oriented towards in the model
+	 * @param targetDirection the {@link Direction} to which the shape should be rotated
+	 * @param baseShape the original {@link VoxelShape} to be rotated
+	 * @return the rotated {@link VoxelShape} after applying the specified transformation
+	 */
+	protected @NotNull VoxelShape rotateHorizontalPlaneDirection(@NotNull Direction modelDirection, @NotNull Direction targetDirection, @NotNull VoxelShape baseShape) {
+		// If model and target directions are the same, no rotation needed
+		if (modelDirection == targetDirection) {
+			return baseShape;
+		}
+
+		// Calculate the rotation needed (in 90-degree increments clockwise)
+		int rotationSteps = getRotationSteps(modelDirection, targetDirection);
+
+		VoxelShape result = baseShape;
+		for (int i = 0; i < rotationSteps; i++) {
+			result = rotateClockwise90(result);
+		}
+
+		return result;
+	}
+
+	/**
+	 * Calculate the number of 90-degree clockwise rotation steps needed to go from model to the target direction
+	 */
+	private int getRotationSteps(Direction modelDirection, Direction targetDirection) {
+		int modelIndex = getDirectionIndex(modelDirection);
+		int targetIndex = getDirectionIndex(targetDirection);
+
+		// Calculate clockwise steps needed
+		return (targetIndex - modelIndex + 4) % 4;
+	}
+
+	/**
+	 * Convert a direction to index for rotation calculation
+	 * SOUTH=0, EAST=1, NORTH=2, WEST=3 (clockwise order)
+	 */
+	private int getDirectionIndex(Direction direction) {
+		return switch (direction) {
+			case SOUTH -> 0;
+			case EAST -> 1;
+			case NORTH -> 2;
+			case WEST -> 3;
+			default -> 0;
+		};
+	}
+
+	/**
+	 * Rotate a shape 90 degrees clockwise around the center point (8, 8)
+	 */
+	private VoxelShape rotateClockwise90(VoxelShape shape) {
+		double[] dims = getShapeDimensions(shape);
+		double minX = dims[0];
+		double minZ = dims[1];
+		double maxX = dims[2];
+		double maxZ = dims[3];
+
+		// 90° clockwise rotation: (x, z) -> (z, 16-x)
+		double newMinZ = 16.0D - maxX;
+		double newMaxZ = 16.0D - minX;
+
+		return Block.box(minZ, 0.0D, newMinZ, maxZ, 16.0D, newMaxZ);
+	}
 }

--- a/src/main/java/com/arrl/radiocraft/common/blocks/DoubleVHFAntennaBlock.java
+++ b/src/main/java/com/arrl/radiocraft/common/blocks/DoubleVHFAntennaBlock.java
@@ -8,7 +8,6 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.BlockPlaceContext;
-import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.LevelReader;
@@ -23,17 +22,14 @@ import net.minecraft.world.level.block.state.properties.DirectionProperty;
 import net.minecraft.world.level.block.state.properties.DoubleBlockHalf;
 import net.minecraft.world.level.block.state.properties.EnumProperty;
 import net.minecraft.world.level.material.Fluids;
-import net.minecraft.world.phys.shapes.CollisionContext;
-import net.minecraft.world.phys.shapes.VoxelShape;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nullable;
 
-public class DoubleVHFAntennaBlock extends VHFAntennaCenterBlock {
+public abstract class DoubleVHFAntennaBlock extends VHFAntennaCenterBlock {
 
     public static final EnumProperty<DoubleBlockHalf> HALF = BlockStateProperties.DOUBLE_BLOCK_HALF;
     public static final DirectionProperty FACING = BlockStateProperties.HORIZONTAL_FACING;
-    public static final VoxelShape SHAPE = Block.box(4.0D, 0.0D, 4.0D, 12.0D, 16.0D, 12.0D);
 
     public DoubleVHFAntennaBlock(Properties properties) {
         super(properties);
@@ -115,10 +111,4 @@ public class DoubleVHFAntennaBlock extends VHFAntennaCenterBlock {
     public @Nullable BlockEntity newBlockEntity(@NotNull BlockPos pos, @NotNull BlockState state) {
         return state.getValue(HALF) == DoubleBlockHalf.LOWER ? new AntennaBlockEntity(pos, state, AntennaNetworkManager.VHF_ID) : null;
     }
-
-    @Override
-    public @NotNull VoxelShape getShape(@NotNull BlockState state, @NotNull BlockGetter level, @NotNull BlockPos pos, @NotNull CollisionContext context) {
-        return SHAPE;
-    }
-
 }

--- a/src/main/java/com/arrl/radiocraft/common/blocks/JPoleAntennaBlock.java
+++ b/src/main/java/com/arrl/radiocraft/common/blocks/JPoleAntennaBlock.java
@@ -1,7 +1,6 @@
 package com.arrl.radiocraft.common.blocks;
 
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.Direction;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
@@ -9,20 +8,20 @@ import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import org.jetbrains.annotations.NotNull;
 
-public class YagiAntennaBlock extends DoubleVHFAntennaBlock {
-    public static final VoxelShape POST = Block.box(11.0D, 0.0D, 6.0D, 15.0D, 16.0D, 10.0D);
+public class JPoleAntennaBlock extends DoubleVHFAntennaBlock {
+    public static final VoxelShape SHAPE = Block.box(4.0D, 0.0D, 4.0D, 12.0D, 16.0D, 12.0D);
 
-    public YagiAntennaBlock(Properties properties) {
+    public JPoleAntennaBlock(Properties properties) {
         super(properties);
     }
 
     @Override
     public @NotNull VoxelShape getShape(@NotNull BlockState state, @NotNull BlockGetter level, @NotNull BlockPos pos, @NotNull CollisionContext context) {
-        return rotateHorizontalPlaneDirection(Direction.WEST, state.getValue(FACING), POST);
+        return SHAPE;
     }
 
     @Override
-    protected @NotNull VoxelShape getCollisionShape(BlockState state, @NotNull BlockGetter level, @NotNull BlockPos pos, @NotNull CollisionContext context) {
-        return rotateHorizontalPlaneDirection(Direction.WEST, state.getValue(FACING), POST);
+    protected @NotNull VoxelShape getCollisionShape(@NotNull BlockState state, @NotNull BlockGetter level, @NotNull BlockPos pos, @NotNull CollisionContext context) {
+        return SHAPE;
     }
 }

--- a/src/main/java/com/arrl/radiocraft/common/init/RadiocraftBlocks.java
+++ b/src/main/java/com/arrl/radiocraft/common/init/RadiocraftBlocks.java
@@ -57,7 +57,7 @@ public class RadiocraftBlocks {
 	public static final DeferredHolder<Block, AntennaConnectorBlock> ANTENNA_CONNECTOR = BLOCKS.register("antenna_connector", () -> new AntennaConnectorBlock(PROPERTIES_STONE_NO_OCCLUDE));
 	public static final DeferredHolder<Block, BalunBlock> BALUN_ONE_TO_ONE = BLOCKS.register("balun_one_to_one", () -> new BalunBlock(PROPERTIES_STONE_NO_OCCLUDE));
 	public static final DeferredHolder<Block, BalunBlock> BALUN_TWO_TO_ONE = BLOCKS.register("balun_two_to_one", () -> new BalunBlock(PROPERTIES_STONE_NO_OCCLUDE));
-	public static final DeferredHolder<Block, DoubleVHFAntennaBlock> J_POLE_ANTENNA = BLOCKS.register("j_pole_antenna", () -> new DoubleVHFAntennaBlock(PROPERTIES_STONE_NO_OCCLUDE));
+	public static final DeferredHolder<Block, JPoleAntennaBlock> J_POLE_ANTENNA = BLOCKS.register("j_pole_antenna", () -> new JPoleAntennaBlock(PROPERTIES_STONE_NO_OCCLUDE));
 	public static final DeferredHolder<Block, VHFAntennaCenterBlock> SLIM_JIM_ANTENNA = BLOCKS.register("slim_jim_antenna", () -> new VHFAntennaCenterBlock(PROPERTIES_STONE_NO_OCCLUDE));
 	public static final DeferredHolder<Block, YagiAntennaBlock> YAGI_ANTENNA = BLOCKS.register("yagi_antenna", () -> new YagiAntennaBlock(PROPERTIES_STONE_NO_OCCLUDE));
 


### PR DESCRIPTION
Fixes #36 

* Added collisions to both JPoleAntennaBlock and YagiAntennaBlock
* Refactored JPoleAntennaBlock out of DoubleVHFAntennaBlock (which is shared with the Yagi)
* Added shape rotation methods to AbstractNetworkBlock for use in the Yagi code (and can be reused for other blocks)
* Updated Yagi code to remove multiple rotations of the hitbox which can be calculated

Note: AI was used to generate entire methods in the AbstractNetworkBlock class implementation; extra scrutiny may be warranted.