### PR TITLE
Implements VOX

### DIFF
--- a/src/main/java/com/arrl/radiocraft/client/RadiocraftClientValues.java
+++ b/src/main/java/com/arrl/radiocraft/client/RadiocraftClientValues.java
@@ -9,4 +9,6 @@ public class RadiocraftClientValues {
 
 	public static boolean SCREEN_CW_ENABLED = false; // Used for recording morse input buffers
 
+	public static VoxStateEnum RADIO_VOX_MODE = VoxStateEnum.INACTIVE; // Used for showing if VOX is running on the radio
+
 }

--- a/src/main/java/com/arrl/radiocraft/client/VoxStateEnum.java
+++ b/src/main/java/com/arrl/radiocraft/client/VoxStateEnum.java
@@ -1,0 +1,6 @@
+package com.arrl.radiocraft.client;
+
+public enum VoxStateEnum {
+    INACTIVE,
+    ACTIVE,
+}

--- a/src/main/java/com/arrl/radiocraft/mixin/MixinVoiceActivation.java
+++ b/src/main/java/com/arrl/radiocraft/mixin/MixinVoiceActivation.java
@@ -1,0 +1,66 @@
+package com.arrl.radiocraft.mixin;
+
+import com.arrl.radiocraft.Radiocraft;
+import com.arrl.radiocraft.client.RadiocraftClientValues;
+import com.arrl.radiocraft.client.VoxStateEnum;
+import de.maxhenkel.voicechat.VoicechatClient;
+import de.maxhenkel.voicechat.voice.client.MicActivator;
+import de.maxhenkel.voicechat.voice.common.Utils;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.function.Consumer;
+
+/**
+ * Mixin to override the voice activation system in Simple Voice Chat.
+ * This allows RadioCraft to control when the microphone should be active based on
+ * the radio's VOX mode setting.
+ */
+@Mixin(value = MicActivator.class, remap = false)
+public class MixinVoiceActivation {
+
+    // Shadow the private fields from MicActivator
+    @Shadow private boolean activating;
+    @Shadow private int deactivationDelay;
+    @Shadow private short[] lastBuff;
+    @Shadow public void stopActivating() {}
+
+    @Inject(method = "push", at = @At("RETURN"), cancellable = true)
+    private void push(short[] audio, Consumer<short[]> audioConsumer, CallbackInfoReturnable<Boolean> cir) {
+        boolean consumedAudio = false;
+        boolean aboveThreshold = Utils.isAboveThreshold(audio, (Double) VoicechatClient.CLIENT_CONFIG.voiceActivationThreshold.get());
+        if (this.activating) {
+            if (!aboveThreshold) {
+                if (this.deactivationDelay >= (Integer)VoicechatClient.CLIENT_CONFIG.deactivationDelay.get()) {
+                    this.stopActivating();
+                    RadiocraftClientValues.RADIO_VOX_MODE = VoxStateEnum.INACTIVE;
+                    System.out.println(RadiocraftClientValues.RADIO_VOX_MODE);
+                } else {
+                    audioConsumer.accept(audio);
+                    consumedAudio = true;
+                    ++this.deactivationDelay;
+                }
+            } else {
+                audioConsumer.accept(audio);
+                consumedAudio = true;
+            }
+        } else if (aboveThreshold) {
+            if (this.lastBuff != null) {
+                audioConsumer.accept(this.lastBuff);
+            }
+
+            audioConsumer.accept(audio);
+            consumedAudio = true;
+            this.activating = true;
+            RadiocraftClientValues.RADIO_VOX_MODE = VoxStateEnum.ACTIVE;
+            System.out.println(RadiocraftClientValues.RADIO_VOX_MODE);
+        }
+
+        this.lastBuff = consumedAudio ? null : audio;
+        cir.setReturnValue(consumedAudio);
+    }
+}

--- a/src/main/resources/radiocraft.mixins.json
+++ b/src/main/resources/radiocraft.mixins.json
@@ -4,7 +4,8 @@
   "compatibilityLevel": "JAVA_21",
   "refmap": "radiocraft.refmap.json",
   "mixins": [
-    "MixinPTTKeyHandler"
+    "MixinPTTKeyHandler",
+    "MixinVoiceActivation"
   ],
   "client": [
   ],


### PR DESCRIPTION
Adds VOX features to radios (Basically, enable transmitting on audio received w/o holding PTT)

Success Critieria:
* Make the radio TX LED turn on when VOX is actively transmitting their audio
* (Eventually) the radio needs to consume power wile VOX is on

Implementation Notes:
- [x] VOX Mixin to get the VOX state from SVC
- [ ] VOX Mixin to get/set whether SVC is in PTT/VOX mode (allow the held/used radio/microphone to change modes)
- [ ] Add VOX indication via TX LED on radio
- [ ] Consume power (only if power has been implemented in the radios at the time of review)

Bounty is $30. Implementation will require coordination with @pop1040 to make sure that VOX is implemented correctly with voice threads.