### PR TITLE
Fix to make the power meter go to zero when the radio is off

### DIFF
--- a/src/main/java/com/arrl/radiocraft/client/screens/radios/VHFHandheldScreen.java
+++ b/src/main/java/com/arrl/radiocraft/client/screens/radios/VHFHandheldScreen.java
@@ -95,8 +95,10 @@ public class VHFHandheldScreen extends Screen {
 
         if (cap.isPowered() && cap.isPTTDown()) {
             POWER_METER.setValue(1.0);
-        } else {
+        } else if (cap.isPowered()) {
             POWER_METER.setValue(Math.random() / 10.0);
+        } else {
+            POWER_METER.setValue(0.0);
         }
 
         if (cap.isPowered()) {


### PR DESCRIPTION
The power meter was always on. This is unrealistic radio behavior.