### PR TITLE
PTT Handheld Fix (For Controllable Support)

### DIFF
--- a/src/main/java/com/arrl/radiocraft/CommonConfig.java
+++ b/src/main/java/com/arrl/radiocraft/CommonConfig.java
@@ -15,6 +15,7 @@ public class CommonConfig {
 	public static final ModConfigSpec.ConfigValue<Integer> SOLAR_PANEL_MAX_OUTPUT;
 	public static final ModConfigSpec.ConfigValue<Double> SOLAR_PANEL_RAIN_MULTIPLIER;
 
+    public static final ModConfigSpec.ConfigValue<Integer> PTT_HELD_RELEASE_TIME_MS;
 	public static final ModConfigSpec.ConfigValue<Integer> HF_RADIO_10M_RECEIVE_TICK;
 	public static final ModConfigSpec.ConfigValue<Integer> HF_RADIO_10M_TRANSMIT_TICK;
 	public static final ModConfigSpec.ConfigValue<Integer> HF_RADIO_20M_RECEIVE_TICK;
@@ -34,9 +35,6 @@ public class CommonConfig {
 	public static final ModConfigSpec.ConfigValue<Integer> QRP_RADIO_40M_RECEIVE_TICK;
 	public static final ModConfigSpec.ConfigValue<Integer> QRP_RADIO_40M_TRANSMIT_TICK;
 
-
-
-
 	static {
 		BUILDER.push("Power Options ( * = Restart game to take effect)");
 		LARGE_BATTERY_CAPACITY = BUILDER.comment("*Energy capacity of large batteries. #default 1500000 integer").define("large_battery_capacity", 1500000);
@@ -49,6 +47,12 @@ public class CommonConfig {
 		BUILDER.pop();
 
 		BUILDER.push("Radio Options ( * = Restart game to take effect)");
+        /*
+          PTT_HELD_RELEASE_TIME_MS: Time to continue transmitting after last PTT held event received from use event
+          You might find if your client has fairly low FPS that you will want to set this value higher than 200ms. 200ms should handle as low as 5 FPS. Maximum value is 1000ms or 1 FPS.
+          Setting this value below 50ms will have little to no effect as the voice packets are buffered at 20ms of samples and the game tick is 50ms per.
+         */
+        PTT_HELD_RELEASE_TIME_MS = BUILDER.comment("*Time to continue transmitting after last PTT held event #default 1000").defineInRange("ptt_held_release_time_ms", 200, 50, 1000);
 		HF_RADIO_10M_RECEIVE_TICK = BUILDER.comment("*HF Radio (10m) power consumption per tick (while receiving) #default 125").define("hf_radio_10m_receive", 125);
 		HF_RADIO_10M_TRANSMIT_TICK = BUILDER.comment("*HF Radio (10m) power consumption per tick (while transmitting) #default 375").define("hf_radio_10m_transmit", 375);
 		HF_RADIO_20M_RECEIVE_TICK = BUILDER.comment("*HF Radio (20m) power consumption per tick (while receiving) #default 125").define("hf_radio_20m_receive", 125);

--- a/src/main/java/com/arrl/radiocraft/client/RadiocraftClientValues.java
+++ b/src/main/java/com/arrl/radiocraft/client/RadiocraftClientValues.java
@@ -4,8 +4,8 @@ public class RadiocraftClientValues {
 
 	public static float NOISE_VOLUME = 0.0F;
 
-	public static boolean SCREEN_PTT_PRESSED = false; // These 2 values are for the voice chat PTT mixin
-	public static boolean SCREEN_VOICE_ENABLED = false;
+	public static boolean PTT_PRESSED = false; // These 2 values are for the voice chat PTT mixin
+	public static boolean VOICE_ENABLED = false;
 
 	public static boolean SCREEN_CW_ENABLED = false; // Used for recording morse input buffers
 

--- a/src/main/java/com/arrl/radiocraft/client/events/ClientTick.java
+++ b/src/main/java/com/arrl/radiocraft/client/events/ClientTick.java
@@ -1,5 +1,6 @@
 package com.arrl.radiocraft.client.events;
 
+import com.arrl.radiocraft.CommonConfig;
 import com.arrl.radiocraft.Radiocraft;
 import com.arrl.radiocraft.client.RadiocraftClientValues;
 import com.arrl.radiocraft.common.network.serverbound.SPlayerClickHoldUpdate;
@@ -10,6 +11,7 @@ import net.minecraft.world.entity.player.Player;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.fml.event.config.ModConfigEvent;
 import net.neoforged.neoforge.client.event.ClientTickEvent;
 
 import java.util.Optional;
@@ -19,8 +21,33 @@ import static com.arrl.radiocraft.common.capabilities.RadiocraftCapabilities.VHF
 @EventBusSubscriber(modid = Radiocraft.MOD_ID, value = Dist.CLIENT)
 public class ClientTick {
 
+    // How long to hold the PTT button before it is considered a release from lack of held event (milliseconds)
+    private static long PTT_HOLD_MS = 200;
 
-    private static boolean wasUseHeld = false;
+    private static boolean wasPttHeld = false;
+    private static long lastPttAction = 0;
+
+    public static void pttActivated() {
+        lastPttAction = System.currentTimeMillis();
+        SPlayerClickHoldUpdate.updateServer(true);
+        RadiocraftClientValues.PTT_PRESSED = true;
+        RadiocraftClientValues.VOICE_ENABLED = true;
+
+        if (!wasPttHeld) {
+            Minecraft.getInstance().getSoundManager().play(SimpleSoundInstance.forUI(SoundEvents.UI_BUTTON_CLICK, 1.0F));
+            wasPttHeld = true;
+        }
+    }
+
+    @SubscribeEvent
+    public static void onConfigLoad(ModConfigEvent.Loading configEvent) {
+        PTT_HOLD_MS = CommonConfig.PTT_HELD_RELEASE_TIME_MS.get();
+    }
+
+    @SubscribeEvent
+    public static void onConfigReloaded(ModConfigEvent.Reloading configEvent) {
+        PTT_HOLD_MS = CommonConfig.PTT_HELD_RELEASE_TIME_MS.get();
+    }
 
     /**
      * Handles right click to PTT on VHF handhelds
@@ -28,27 +55,14 @@ public class ClientTick {
      */
     @SubscribeEvent
     public static void onClientTick(ClientTickEvent.Post event) {
-
-        boolean isUseHeld = Minecraft.getInstance().options.keyUse.isDown();
-
-        if(isUseHeld != wasUseHeld) {
-            SPlayerClickHoldUpdate.updateServer(isUseHeld);
-
-            boolean holdingRadio = Optional.ofNullable(Minecraft.getInstance().player).map(Player::getMainHandItem).map(i -> i.getCapability(VHF_HANDHELDS)).isPresent();
-
-            RadiocraftClientValues.SCREEN_PTT_PRESSED =
-                    RadiocraftClientValues.SCREEN_VOICE_ENABLED =
-                            isUseHeld && !Minecraft.getInstance().options.keyShift.isDown() && holdingRadio;
-
-            if(holdingRadio && !Minecraft.getInstance().options.keyShift.isDown()) {
-                if(isUseHeld) {
-                    Minecraft.getInstance().getSoundManager().play(SimpleSoundInstance.forUI(SoundEvents.UI_BUTTON_CLICK, 1.0F));
-                } else {
-                    Minecraft.getInstance().getSoundManager().play(SimpleSoundInstance.forUI(SoundEvents.UI_BUTTON_CLICK, 1.3f));
-                }
-            }
+        // Check if the PTT button hold has expired if we have not already set it as unheld
+        if (System.currentTimeMillis() - lastPttAction > PTT_HOLD_MS && wasPttHeld) {
+            // Timeout has passed, reset the state
+            try { SPlayerClickHoldUpdate.updateServer(false); } catch (NullPointerException ignored) {}
+            RadiocraftClientValues.PTT_PRESSED = false;
+            RadiocraftClientValues.VOICE_ENABLED = false;
+            wasPttHeld = false;
+            Minecraft.getInstance().getSoundManager().play(SimpleSoundInstance.forUI(SoundEvents.UI_BUTTON_CLICK, 1.3f));
         }
-
-        wasUseHeld = isUseHeld;
     }
 }

--- a/src/main/java/com/arrl/radiocraft/client/screens/radios/HFRadioScreen.java
+++ b/src/main/java/com/arrl/radiocraft/client/screens/radios/HFRadioScreen.java
@@ -21,11 +21,11 @@ public abstract class HFRadioScreen<T extends RadioMenu<? extends HFRadioBlockEn
 		super.render(pGuiGraphics, pMouseX, pMouseY, pPartialTick);
 
 		if(menu.blockEntity.getCWEnabled()) {
-			if(RadiocraftClientValues.SCREEN_PTT_PRESSED)
+			if(RadiocraftClientValues.PTT_PRESSED)
 				menu.blockEntity.getCWSendBuffer().setShouldAccumulate();
 		}
 		RadiocraftClientValues.SCREEN_CW_ENABLED = menu.blockEntity.getCWEnabled();
-		RadiocraftClientValues.SCREEN_VOICE_ENABLED = menu.blockEntity.getSSBEnabled();
+		RadiocraftClientValues.VOICE_ENABLED = menu.blockEntity.getSSBEnabled();
 	}
 
 	@Override

--- a/src/main/java/com/arrl/radiocraft/client/screens/radios/RadioScreen.java
+++ b/src/main/java/com/arrl/radiocraft/client/screens/radios/RadioScreen.java
@@ -34,8 +34,8 @@ public abstract class RadioScreen<T extends RadioMenu<?>> extends AbstractContai
 	@Override
 	public void onClose() {
 		super.onClose();
-		RadiocraftClientValues.SCREEN_PTT_PRESSED = false; // Make sure to stop recording player's mic when the UI is closed, in case they didn't let go of PTT
-		RadiocraftClientValues.SCREEN_VOICE_ENABLED = false;
+		RadiocraftClientValues.PTT_PRESSED = false; // Make sure to stop recording player's mic when the UI is closed, in case they didn't let go of PTT
+		RadiocraftClientValues.VOICE_ENABLED = false;
 		RadiocraftClientValues.SCREEN_CW_ENABLED = false;
 	}
 
@@ -100,7 +100,7 @@ public abstract class RadioScreen<T extends RadioMenu<?>> extends AbstractContai
 	 */
 	protected void onPressPTT(HoldButton button) {
 		//RadiocraftPackets.sendToServer(new SRadioPTTPacket(menu.blockEntity.getBlockPos(), true));
-		RadiocraftClientValues.SCREEN_PTT_PRESSED = true;
+		RadiocraftClientValues.PTT_PRESSED = true;
 	}
 
 	/**
@@ -108,7 +108,7 @@ public abstract class RadioScreen<T extends RadioMenu<?>> extends AbstractContai
 	 */
 	protected void onReleasePTT(HoldButton button) {
 		//RadiocraftPackets.sendToServer(new SRadioPTTPacket(menu.blockEntity.getBlockPos(), false));
-		RadiocraftClientValues.SCREEN_PTT_PRESSED = false;
+		RadiocraftClientValues.PTT_PRESSED = false;
 	}
 
 	/**

--- a/src/main/java/com/arrl/radiocraft/client/screens/radios/VHFHandheldScreen.java
+++ b/src/main/java/com/arrl/radiocraft/client/screens/radios/VHFHandheldScreen.java
@@ -54,7 +54,7 @@ public class VHFHandheldScreen extends Screen {
         if(this.cap == null) // IntelliJ is lying, this is not always true.
             onClose();
 
-        RadiocraftClientValues.SCREEN_VOICE_ENABLED = true;
+        RadiocraftClientValues.VOICE_ENABLED = true;
     }
 
     protected void updateCap(){
@@ -203,8 +203,8 @@ public class VHFHandheldScreen extends Screen {
     @Override
     public void onClose() {
         super.onClose();
-        RadiocraftClientValues.SCREEN_PTT_PRESSED = false; // Make sure to stop recording player's mic when the UI is closed, in case they didn't let go of PTT
-        RadiocraftClientValues.SCREEN_VOICE_ENABLED = false;
+        RadiocraftClientValues.PTT_PRESSED = false; // Make sure to stop recording player's mic when the UI is closed, in case they didn't let go of PTT
+        RadiocraftClientValues.VOICE_ENABLED = false;
         RadiocraftClientValues.SCREEN_CW_ENABLED = false;
         if(cap.isPTTDown()) {
             cap.setPTTDown(false);
@@ -300,7 +300,7 @@ public class VHFHandheldScreen extends Screen {
     protected void onPressPTT(HoldButton button) {
         //RadiocraftPackets.sendToServer(new SHandheldPTTPacket(index, true));
         cap.setPTTDown(true);
-        RadiocraftClientValues.SCREEN_PTT_PRESSED = true;
+        RadiocraftClientValues.PTT_PRESSED = true;
         updateServer();
     }
 
@@ -310,7 +310,7 @@ public class VHFHandheldScreen extends Screen {
     protected void onReleasePTT(HoldButton button) {
         //RadiocraftPackets.sendToServer(new SHandheldPTTPacket(index, false));
         cap.setPTTDown(false);
-        RadiocraftClientValues.SCREEN_PTT_PRESSED = false;
+        RadiocraftClientValues.PTT_PRESSED = false;
         updateServer();
     }
 

--- a/src/main/java/com/arrl/radiocraft/client/screens/radios/VHFRadioScreen.java
+++ b/src/main/java/com/arrl/radiocraft/client/screens/radios/VHFRadioScreen.java
@@ -10,7 +10,7 @@ public abstract class VHFRadioScreen<T extends RadioMenu<?>> extends RadioScreen
 
     public VHFRadioScreen(T menu, Inventory inventory, Component title, ResourceLocation texture, ResourceLocation widgetsTexture) {
         super(menu, inventory, title, texture, widgetsTexture);
-        RadiocraftClientValues.SCREEN_VOICE_ENABLED = true;
+        RadiocraftClientValues.VOICE_ENABLED = true;
     }
 
 }

--- a/src/main/java/com/arrl/radiocraft/common/items/VHFHandheldItem.java
+++ b/src/main/java/com/arrl/radiocraft/common/items/VHFHandheldItem.java
@@ -1,9 +1,9 @@
 package com.arrl.radiocraft.common.items;
 
 import com.arrl.radiocraft.api.capabilities.IVHFHandheldCapability;
+import com.arrl.radiocraft.client.events.ClientTick;
 import com.arrl.radiocraft.client.screens.radios.VHFHandheldScreen;
 import com.arrl.radiocraft.common.init.RadiocraftItems;
-import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResultHolder;
@@ -12,6 +12,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
+import org.jetbrains.annotations.NotNull;
 
 import static com.arrl.radiocraft.common.capabilities.RadiocraftCapabilities.VHF_HANDHELDS;
 
@@ -22,12 +23,16 @@ public class VHFHandheldItem extends Item {
     }
 
     @Override
-    public InteractionResultHolder<ItemStack> use(Level level, Player player, InteractionHand hand) {
+    public @NotNull InteractionResultHolder<ItemStack> use(@NotNull Level level, Player player, @NotNull InteractionHand hand) {
         ItemStack item = player.getItemInHand(hand);
 
         if(hand == InteractionHand.MAIN_HAND) {
-            if(level.isClientSide() && player.isCrouching()) {
-                VHFHandheldScreen.open(player.getInventory().selected); // The open call is in a different class so the server doesn't try to load it.
+            if(level.isClientSide()) {
+                if (player.isCrouching()) {
+                    VHFHandheldScreen.open(player.getInventory().selected);// The open call is in a different class so the server doesn't try to load it.
+                } else {
+                    ClientTick.pttActivated();
+                }
             }
             if(!player.isCrouching()){
                 return InteractionResultHolder.pass(item); //prevents bob animation on use key (aka right click)

--- a/src/main/java/com/arrl/radiocraft/mixin/MixinPTTKeyHandler.java
+++ b/src/main/java/com/arrl/radiocraft/mixin/MixinPTTKeyHandler.java
@@ -8,7 +8,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 /*
-TODO: Fix the mixin. This is required to be able to use the PTT functionality without requiring an actual key press
+This is required to be able to use the PTT functionality of SVC without requiring an actual key press
 This is used in the GUI pane for the radios; a PTT button on the GUI screen can be clicked in place of using the PTT key.
 
 The source code from the simple voice chat mod:
@@ -24,13 +24,13 @@ public class MixinPTTKeyHandler {
 
 	@Inject(method="isPTTDown", at=@At("HEAD"), cancellable = true, remap = false)
 	private void isPTTDown(CallbackInfoReturnable<Boolean> cir) {
-		if(RadiocraftClientValues.SCREEN_PTT_PRESSED && RadiocraftClientValues.SCREEN_VOICE_ENABLED)
+		if(RadiocraftClientValues.PTT_PRESSED && RadiocraftClientValues.VOICE_ENABLED)
 			cir.setReturnValue(true);
 	}
 
 	@Inject(method="isAnyDown", at=@At("HEAD"), cancellable = true, remap = false)
 	private void isAnyDown(CallbackInfoReturnable<Boolean> cir) {
-		if(RadiocraftClientValues.SCREEN_PTT_PRESSED && RadiocraftClientValues.SCREEN_VOICE_ENABLED)
+		if(RadiocraftClientValues.PTT_PRESSED && RadiocraftClientValues.VOICE_ENABLED)
 			cir.setReturnValue(true);
 	}
 


### PR DESCRIPTION
I made quite a few changes and refactors with this one. The major change is that we no longer use the client tick handler to run click events and instead rely on the use event to trigger PTT. This comes with the side effect of allowing PTT to be handled with a release timer (which is realistic radio operation).

Testing concluded that both a controller and mouse worked for this.

I also added a line in the config to control the hold time after PTT is released.

Fixes #74