### PR TITLE
Antenna work

### DIFF
--- a/src/main/java/com/arrl/radiocraft/api/antenna/IAntenna.java
+++ b/src/main/java/com/arrl/radiocraft/api/antenna/IAntenna.java
@@ -1,6 +1,7 @@
 package com.arrl.radiocraft.api.antenna;
 
 import com.arrl.radiocraft.common.radio.antenna.AntennaCWPacket;
+import com.arrl.radiocraft.common.radio.antenna.AntennaData;
 import com.arrl.radiocraft.common.radio.antenna.AntennaVoicePacket;
 import com.arrl.radiocraft.common.radio.antenna.StaticAntenna;
 import com.arrl.radiocraft.common.radio.morse.CWBuffer;
@@ -57,6 +58,18 @@ public interface IAntenna {
 	 * @return Position of this antenna
 	 */
 	AntennaPos getAntennaPos();
+
+    /**
+     * Get the type of this antenna.
+     * @return The type of this antenna.
+     */
+    IAntennaType<? extends AntennaData> getType();
+
+    /**
+     * Get the data for this antenna.
+     * @return The data for this antenna.
+     */
+    AntennaData getData();
 
 	/**
 	 * Immutable single record for the position of an antenna. Used for calculating signal strengths.

--- a/src/main/java/com/arrl/radiocraft/api/antenna/IAntennaType.java
+++ b/src/main/java/com/arrl/radiocraft/api/antenna/IAntennaType.java
@@ -67,6 +67,8 @@ public interface IAntennaType<T extends AntennaData> {
 	/**
 	 * Calculates the SWR of an antenna for a given wavelength based on it's properties. This has an
 	 * impact on the efficiency of the antenna.
+     *
+     * TODO: Make this take a (center) frequency in MHz from the Band data, instead of this garbage int for a wavelength
 	 *
 	 * @param data {@link AntennaData} object belonging to this antenna.
 	 * @param wavelength The wavelength to be used for checking SWR.

--- a/src/main/java/com/arrl/radiocraft/common/commands/AntennaNetworkCommands.java
+++ b/src/main/java/com/arrl/radiocraft/common/commands/AntennaNetworkCommands.java
@@ -1,0 +1,52 @@
+package com.arrl.radiocraft.common.commands;
+
+import com.arrl.radiocraft.Radiocraft;
+import com.arrl.radiocraft.api.antenna.IAntenna;
+import com.arrl.radiocraft.common.radio.antenna.AntennaNetwork;
+import com.arrl.radiocraft.common.radio.antenna.networks.AntennaNetworkManager;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+
+public class AntennaNetworkCommands {
+    public static final LiteralArgumentBuilder<CommandSourceStack> BUILDER = Commands.literal("antenna")
+            .executes(command -> listAntennas(command.getSource()));
+
+    private static String toStringEvenNull(Object o) {
+        return o == null ? "null" : o.toString();
+    }
+
+    private static int listAntennas(CommandSourceStack source) {
+
+        ArrayList<String> antennaInfos = new ArrayList<>();
+        antennaInfos.add("Antenna Networks:");
+
+        for (Map.Entry<ResourceLocation, AntennaNetwork> entry: AntennaNetworkManager.networks.entrySet()) {
+            String entryName = entry.getKey().toString();
+
+            Set<IAntenna> antennas = entry.getValue().allAntennas();
+
+            Radiocraft.LOGGER.info(String.format("Antenna Network %s has %d antennas", entryName, antennas.size()));
+            Radiocraft.LOGGER.info(antennas.toString());
+
+
+
+            List<String> antennaData = antennas.stream().map((antenna) -> toStringEvenNull(antenna.getAntennaPos())).toList();
+
+            antennaInfos.add(String.format("%s %s", entryName, antennaData));
+        }
+
+        Supplier<Component> combined = () -> Component.literal(String.join("\n", antennaInfos));
+
+        source.sendSuccess(combined, true);
+        return 1;
+    }
+}

--- a/src/main/java/com/arrl/radiocraft/common/init/RadiocraftCommands.java
+++ b/src/main/java/com/arrl/radiocraft/common/init/RadiocraftCommands.java
@@ -1,6 +1,7 @@
 package com.arrl.radiocraft.common.init;
 
 import com.arrl.radiocraft.Radiocraft;
+import com.arrl.radiocraft.common.commands.AntennaNetworkCommands;
 import com.arrl.radiocraft.common.commands.CallsignCommands;
 import com.arrl.radiocraft.common.commands.SolarWeatherCommands;
 import net.neoforged.bus.api.SubscribeEvent;
@@ -14,5 +15,6 @@ public class RadiocraftCommands {
 	public static void onRegisterCommands(RegisterCommandsEvent event) {
 		event.getDispatcher().register(CallsignCommands.BUILDER);
 		event.getDispatcher().register(SolarWeatherCommands.BUILDER);
+        event.getDispatcher().register(AntennaNetworkCommands.BUILDER);
 	}
 }

--- a/src/main/java/com/arrl/radiocraft/common/init/RadiocraftItems.java
+++ b/src/main/java/com/arrl/radiocraft/common/init/RadiocraftItems.java
@@ -2,10 +2,7 @@ package com.arrl.radiocraft.common.init;
 
 import com.arrl.radiocraft.Radiocraft;
 import com.arrl.radiocraft.common.datacomponents.HandheldRadioState;
-import com.arrl.radiocraft.common.items.AntennaPoleItem;
-import com.arrl.radiocraft.common.items.AntennaWireItem;
-import com.arrl.radiocraft.common.items.SmallBatteryItem;
-import com.arrl.radiocraft.common.items.VHFHandheldItem;
+import com.arrl.radiocraft.common.items.*;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
@@ -36,7 +33,7 @@ public class RadiocraftItems {
 	public static final DeferredHolder<Item, SmallBatteryItem> SMALL_BATTERY = ITEMS.register("small_battery", () -> new SmallBatteryItem(new Properties().stacksTo(1))); //.component(DataComponent.ENERGY_DATA_COMPONENT, new DataComponent.EnergyRecord(1000.0))));
 	public static final Supplier<Item> FERRITE_CORE = simpleItem("ferrite_core", null);
 	public static final Supplier<Item> COAXIAL_CORE = simpleItem("coaxial_core", null);
-	public static final Supplier<Item> ANTENNA_ANALYZER = simpleItem("antenna_analyzer", Component.translatable("tooltip.radiocraft.not_implemented"));
+	public static final Supplier<Item> ANTENNA_ANALYZER = ITEMS.register("antenna_analyzer", () -> new AntennaAnalyzerItem(new Properties().stacksTo(1)));
 	public static final DeferredHolder<Item, VHFHandheldItem> VHF_HANDHELD = ITEMS.register("vhf_handheld", () -> new VHFHandheldItem(new Properties().stacksTo(1).component(RadiocraftDataComponent.HANDHELD_RADIO_STATE_COMPONENT.value(), HandheldRadioState.getDefault())));
 	public static final DeferredHolder<Item, AntennaWireItem> ANTENNA_WIRE = ITEMS.register("antenna_wire", () -> new AntennaWireItem(new Properties()));
 

--- a/src/main/java/com/arrl/radiocraft/common/items/AntennaAnalyzerItem.java
+++ b/src/main/java/com/arrl/radiocraft/common/items/AntennaAnalyzerItem.java
@@ -1,0 +1,105 @@
+package com.arrl.radiocraft.common.items;
+
+import com.arrl.radiocraft.Radiocraft;
+import com.arrl.radiocraft.api.antenna.IAntenna;
+import com.arrl.radiocraft.common.radio.antenna.AntennaNetwork;
+import com.arrl.radiocraft.common.radio.antenna.networks.AntennaNetworkManager;
+import com.arrl.radiocraft.common.radio.antenna.types.RubberDuckyAntennaType;
+import com.arrl.radiocraft.common.radio.antenna.types.data.RubberDuckyAntennaData;
+import com.arrl.radiocraft.common.radio.voice.handheld.PlayerRadio;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.TooltipFlag;
+import net.minecraft.world.item.context.UseOnContext;
+import net.minecraft.world.level.Level;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class AntennaAnalyzerItem extends Item {
+
+    public AntennaAnalyzerItem(Properties properties) {
+        super(properties);
+    }
+
+    private Set<IAntenna> getAntennasAt(Level level, BlockPos pos) {
+        Set<IAntenna> allAntennas = new HashSet<IAntenna>();
+        for (Map.Entry<ResourceLocation, AntennaNetwork> entry: AntennaNetworkManager.networks.entrySet()) {
+            for (IAntenna antenna : entry.getValue().allAntennas()) {
+                IAntenna.AntennaPos ap = antenna.getAntennaPos();
+                if (ap == null) continue;
+                if (ap.level() == level && ap.position().equals(pos)) {
+                    allAntennas.add(antenna);
+                }
+            }
+        }
+        return allAntennas;
+    }
+
+    private IAntenna getPlayerAntenna(Player player) {
+        return AntennaNetworkManager.getNetwork(AntennaNetworkManager.VHF_ID).allAntennas().stream().filter((antenna) -> {
+            IAntenna.AntennaPos ap = antenna.getAntennaPos();
+            if (ap == null) return false;
+            BlockPos playerPos = player.blockPosition();
+            if (ap.level() == player.level() && ap.position().equals(playerPos)) {
+                return antenna.getType() instanceof RubberDuckyAntennaType;
+            }
+            return false;
+        }).findFirst().orElse(null);
+    }
+
+    @Override
+    public @NotNull InteractionResult useOn(@NotNull UseOnContext context) {
+        if(context.getLevel().isClientSide()) { return InteractionResult.PASS; }
+
+        Set<IAntenna> antennas = getAntennasAt(context.getLevel(), context.getClickedPos());
+
+        if (!antennas.isEmpty()) {
+            IAntenna antenna = antennas.iterator().next();
+
+            if (context.getPlayer() != null) {
+                context.getPlayer().displayClientMessage(Component.literal("Antenna network at " + antenna.getAntennaPos().toString() + " has " + antennas.size() + " antennas"), true);
+                return InteractionResult.CONSUME;
+            }
+        }
+
+        if(context.getPlayer() != null) {
+            IAntenna playerRadio = getPlayerAntenna(context.getPlayer());
+            if(playerRadio != null) {
+                RubberDuckyAntennaType type = (RubberDuckyAntennaType) playerRadio.getType();
+                RubberDuckyAntennaData data = (RubberDuckyAntennaData) playerRadio.getData();
+
+                context.getPlayer().displayClientMessage(Component.literal("You are holding a handheld radio, the antenna is " + data.getLength() + "m long and  has an SWR of " + type.getSWR(data, 2)), true);
+                return InteractionResult.CONSUME;
+            } else {
+                context.getPlayer().displayClientMessage(Component.literal("No antenna networks found at " + context.getClickedPos() + "."), true);
+                if (Radiocraft.IS_DEVELOPMENT_ENV) {
+                    Set<IAntenna> allAntennasExceptPlayer = AntennaNetworkManager.getAllAntennas().stream().filter((it) -> !(it instanceof PlayerRadio)).collect(Collectors.toSet());
+                    context.getPlayer().sendSystemMessage(Component.literal("There are " + allAntennasExceptPlayer.size() + " networks in the world: " + String.join(" ", allAntennasExceptPlayer.stream().map(Object::toString).toList())));
+                }
+            }
+        }
+
+        return InteractionResult.PASS;
+    }
+
+    @Override
+    public boolean isEnchantable(@NotNull ItemStack stack) {
+        return false;
+    }
+
+    @Override
+    public void appendHoverText(@NotNull ItemStack stack, @NotNull TooltipContext context, @NotNull List<Component> tooltipComponents, @NotNull TooltipFlag tooltipFlag) {
+        super.appendHoverText(stack, context, tooltipComponents, tooltipFlag);
+        tooltipComponents.add(Component.translatable("tooltip.radiocraft.not_implemented"));
+    }
+}

--- a/src/main/java/com/arrl/radiocraft/common/radio/antenna/StaticAntenna.java
+++ b/src/main/java/com/arrl/radiocraft/common/radio/antenna/StaticAntenna.java
@@ -151,7 +151,17 @@ public class StaticAntenna<T extends AntennaData> implements IAntenna, INBTSeria
 		return pos.get();
 	}
 
-	public void setNetwork(AntennaNetwork network) {
+    @Override
+    public IAntennaType<? extends AntennaData> getType() {
+        return type;
+    }
+
+    @Override
+    public AntennaData getData() {
+        return data;
+    }
+
+    public void setNetwork(AntennaNetwork network) {
 		if(this.network != null)
 			this.network.removeAntenna(this);
 		network.addAntenna(this);

--- a/src/main/java/com/arrl/radiocraft/common/radio/antenna/networks/AntennaNetworkManager.java
+++ b/src/main/java/com/arrl/radiocraft/common/radio/antenna/networks/AntennaNetworkManager.java
@@ -1,13 +1,16 @@
 package com.arrl.radiocraft.common.radio.antenna.networks;
 
 import com.arrl.radiocraft.Radiocraft;
+import com.arrl.radiocraft.api.antenna.IAntenna;
 import com.arrl.radiocraft.api.capabilities.IAntennaNetworkCapability;
 import com.arrl.radiocraft.common.radio.antenna.AntennaNetwork;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.Level;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Helper class for grabbing antenna networks from a level, as well as creating
@@ -36,5 +39,16 @@ public class AntennaNetworkManager {
 	public static AntennaNetwork getNetwork(ResourceLocation id) {
 		return networks.get(id);
 	}
+
+    /**
+     * Get all antennas in all networks. Because aint nobody got time for just getting one network of antennas.
+     * @return Set of antennas
+     */
+    public static Set<IAntenna> getAllAntennas() {
+        HashSet<IAntenna> antennas = new HashSet<>();
+        antennas.addAll(networks.get(HF_ID).allAntennas());
+        antennas.addAll(networks.get(VHF_ID).allAntennas());
+        return antennas;
+    }
 
 }

--- a/src/main/java/com/arrl/radiocraft/common/radio/antenna/types/DipoleAntennaType.java
+++ b/src/main/java/com/arrl/radiocraft/common/radio/antenna/types/DipoleAntennaType.java
@@ -15,7 +15,7 @@ import java.util.List;
 public class DipoleAntennaType extends NonDirectionalAntennaType<DipoleAntennaData> {
 
 	public DipoleAntennaType() {
-		super(Radiocraft.id("dipole"), 1.0D, 1.0D, 1.0D, 1.0D);
+		super(Radiocraft.id("dipole"), 0.0D, 0.0D, 1.0D, 1.0D);
 	}
 
 	@Override

--- a/src/main/java/com/arrl/radiocraft/common/radio/antenna/types/DirectionalAntennaType.java
+++ b/src/main/java/com/arrl/radiocraft/common/radio/antenna/types/DirectionalAntennaType.java
@@ -7,18 +7,20 @@ import net.minecraft.resources.ResourceLocation;
 
 public abstract class DirectionalAntennaType<T extends AntennaData> extends NonDirectionalAntennaType<T> {
 
-    protected DirectionalAntennaType(ResourceLocation id, double receive, double transmit, double los, double skip) {
-        super(id, receive, transmit, los, skip);
+    protected DirectionalAntennaType(ResourceLocation id, double receiveGainDbi, double transmitGainDbi, double los, double skip) {
+        super(id, receiveGainDbi, transmitGainDbi, los, skip);
     }
 
     @Override
     public double getTransmitEfficiency(IAntennaPacket packet, T data, BlockPos destination, boolean isCW) {
-        return super.getTransmitEfficiency(packet, data, destination, isCW) * getDirectionalEfficiency(data, packet.getSource().getAntennaPos().position(), destination);
+        double base = super.getTransmitEfficiency(packet, data, destination, isCW);
+        return base * getDirectionalEfficiency(data, packet.getSource().getAntennaPos().position(), destination);
     }
 
     @Override
     public double getReceiveEfficiency(IAntennaPacket packet, T data, BlockPos pos) {
-        return super.getReceiveEfficiency(packet, data, pos) * getDirectionalEfficiency(data, packet.getSource().getAntennaPos().position(), pos);
+        double base = super.getReceiveEfficiency(packet, data, pos);
+        return base * getDirectionalEfficiency(data, packet.getSource().getAntennaPos().position(), pos);
     }
 
     /**

--- a/src/main/java/com/arrl/radiocraft/common/radio/antenna/types/EndFedAntennaType.java
+++ b/src/main/java/com/arrl/radiocraft/common/radio/antenna/types/EndFedAntennaType.java
@@ -15,7 +15,7 @@ import java.util.List;
 public class EndFedAntennaType extends  NonDirectionalAntennaType<EndFedAntennaData> {
 
 	public EndFedAntennaType() {
-		super(Radiocraft.id("end_fed"), 0.75D, 0.75D, 1.0D, 1.0D);
+		super(Radiocraft.id("end_fed"), -1.25D, -1.25D, 1.0D, 1.0D);
 	}
 
 	@Override
@@ -45,7 +45,7 @@ public class EndFedAntennaType extends  NonDirectionalAntennaType<EndFedAntennaD
 	@Override
 	public double getSWR(EndFedAntennaData data, int wavelength) {
 		int desiredLength = (int)Math.round(wavelength / 4.0D); // The desired length for each "arm" is 1/4 of the wavelength used, round to the nearest int (for example 10m radio -> 3 blocks)
-		double incorrectBlocks = desiredLength - data.getLength();
+		double incorrectBlocks = Math.abs(desiredLength - data.getLength());
 
 		return 1.0D + (0.5D * incorrectBlocks);
 	}

--- a/src/main/java/com/arrl/radiocraft/common/radio/antenna/types/HorizontalQuadLoopAntennaType.java
+++ b/src/main/java/com/arrl/radiocraft/common/radio/antenna/types/HorizontalQuadLoopAntennaType.java
@@ -15,7 +15,7 @@ import java.util.List;
 public class HorizontalQuadLoopAntennaType extends NonDirectionalAntennaType<HorizontalQuadLoopAntennaData> {
 
 	public HorizontalQuadLoopAntennaType() {
-		super(Radiocraft.id("horizontal_quad_loop"), 1.0D, 1.0D, 0.25D, 1.25D);
+		super(Radiocraft.id("horizontal_quad_loop"), 0.0D, 0.0D, 0.25D, 1.25D);
 	}
 
 	@Override

--- a/src/main/java/com/arrl/radiocraft/common/radio/antenna/types/NonDirectionalAntennaType.java
+++ b/src/main/java/com/arrl/radiocraft/common/radio/antenna/types/NonDirectionalAntennaType.java
@@ -9,18 +9,24 @@ import net.minecraft.resources.ResourceLocation;
 
 public abstract class NonDirectionalAntennaType<T extends AntennaData> implements IAntennaType<T> {
 
+    private static final double CW_RANGE_MULTIPLIER = 1.5D;
+
     private final ResourceLocation id;
     private final double los;
     private final double skip;
-    private final double receive;
-    private final double transmit;
+    private final double receiveGainDbi;
+    private final double transmitGainDbi;
+    private final double receiveGainLinear;
+    private final double transmitGainLinear;
 
-    protected NonDirectionalAntennaType(ResourceLocation id, double receive, double transmit, double los, double skip) {
+    protected NonDirectionalAntennaType(ResourceLocation id, double receiveGainDbi, double transmitGainDbi, double los, double skip) {
         this.id = id;
         this.los = los;
         this.skip = skip;
-        this.receive = receive;
-        this.transmit = transmit;
+        this.receiveGainDbi = receiveGainDbi;
+        this.transmitGainDbi = transmitGainDbi;
+        this.receiveGainLinear = dbiToLinear(receiveGainDbi);
+        this.transmitGainLinear = dbiToLinear(transmitGainDbi);
     }
 
     @Override
@@ -30,13 +36,56 @@ public abstract class NonDirectionalAntennaType<T extends AntennaData> implement
 
     @Override
     public double getTransmitEfficiency(IAntennaPacket packet, T data, BlockPos destination, boolean isCW) {
-        double distance = Math.sqrt(packet.getSource().getAntennaPos().position().distSqr(destination));
-        return transmit * BandUtils.getBaseStrength(packet.getWavelength(), isCW ? distance / 1.5D : distance, los, skip, packet.getLevel().isDay());
+        double distance = computeDistance(packet, destination);
+        double adjustedDistance = modifyDistanceForTransmit(packet, data, destination, distance);
+        double propagation = getPropagationStrength(packet, adjustedDistance, isCW);
+        return propagation * getTransmitGainLinear();
     }
 
     @Override
     public double getReceiveEfficiency(IAntennaPacket packet, T data, BlockPos pos) {
-        return receive * packet.getStrength();
+        return getReceiveGainLinear() * packet.getStrength();
+    }
+
+    protected double computeDistance(IAntennaPacket packet, BlockPos destination) {
+        return Math.sqrt(packet.getSource().getAntennaPos().position().distSqr(destination));
+    }
+
+    protected double modifyDistanceForTransmit(IAntennaPacket packet, T data, BlockPos destination, double distance) {
+        return distance;
+    }
+
+    protected double getPropagationStrength(IAntennaPacket packet, double distance, boolean isCW) {
+        double effectiveDistance = isCW ? distance / CW_RANGE_MULTIPLIER : distance;
+        return BandUtils.getBaseStrength(packet.getWavelength(), effectiveDistance, getLosEfficiency(), getSkipEfficiency(), packet.getLevel().isDay());
+    }
+
+    protected double getLosEfficiency() {
+        return los;
+    }
+
+    protected double getSkipEfficiency() {
+        return skip;
+    }
+
+    public double getReceiveGainDbi() {
+        return receiveGainDbi;
+    }
+
+    public double getTransmitGainDbi() {
+        return transmitGainDbi;
+    }
+
+    public double getReceiveGainLinear() {
+        return receiveGainLinear;
+    }
+
+    public double getTransmitGainLinear() {
+        return transmitGainLinear;
+    }
+
+    private static double dbiToLinear(double dbi) {
+        return Math.pow(10.0D, dbi / 10.0D);
     }
 
 }

--- a/src/main/java/com/arrl/radiocraft/common/radio/antenna/types/QuarterWaveVerticalAntennaType.java
+++ b/src/main/java/com/arrl/radiocraft/common/radio/antenna/types/QuarterWaveVerticalAntennaType.java
@@ -12,7 +12,7 @@ import net.minecraft.world.level.Level;
 public class QuarterWaveVerticalAntennaType extends NonDirectionalAntennaType<QuarterWaveVerticalAntennaData> {
 
 	public QuarterWaveVerticalAntennaType() {
-		super(Radiocraft.id("quarter_wave_vertical"), 1.0D, 1.0D, 1.2D, 0.7D);
+		super(Radiocraft.id("quarter_wave_vertical"), 0.0D, 0.0D, 1.2D, 0.7D);
 	}
 
 	@Override

--- a/src/main/java/com/arrl/radiocraft/common/radio/antenna/types/RubberDuckyAntennaType.java
+++ b/src/main/java/com/arrl/radiocraft/common/radio/antenna/types/RubberDuckyAntennaType.java
@@ -1,0 +1,32 @@
+package com.arrl.radiocraft.common.radio.antenna.types;
+
+import com.arrl.radiocraft.Radiocraft;
+import com.arrl.radiocraft.common.radio.antenna.StaticAntenna;
+import com.arrl.radiocraft.common.radio.antenna.types.data.RubberDuckyAntennaData;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
+
+public class RubberDuckyAntennaType extends NonDirectionalAntennaType<RubberDuckyAntennaData> {
+
+    public RubberDuckyAntennaType() {
+        // We might need to workshop these numbers but rubber ducky antennas are pretty awful at much of anything.
+        // Typical datasheets cite roughly -10 to -2 dBi; -3 dBi is a reasonable starting point until playtesting suggests otherwise.
+        super(Radiocraft.id("rubber_ducky"), -3.01D, -3.01D, 1.0, 1.0D);
+    }
+
+    // This is a special type of antenna that does not have a physical in-world placement.
+    @Override
+    public StaticAntenna<RubberDuckyAntennaData> match(Level level, BlockPos pos) {
+        return null;
+    }
+
+    @Override
+    public double getSWR(RubberDuckyAntennaData data, int wavelength) {
+        return (int)Math.abs(Math.round(wavelength / 4.0D));
+    }
+
+    @Override
+    public RubberDuckyAntennaData getDefaultData() {
+        return new RubberDuckyAntennaData(0.1);
+    }
+}

--- a/src/main/java/com/arrl/radiocraft/common/radio/antenna/types/VerticalQuadLoopAntennaType.java
+++ b/src/main/java/com/arrl/radiocraft/common/radio/antenna/types/VerticalQuadLoopAntennaType.java
@@ -16,7 +16,7 @@ import java.util.List;
 public class VerticalQuadLoopAntennaType extends DirectionalAntennaType<VerticalQuadLoopAntennaData> {
 
 	public VerticalQuadLoopAntennaType() {
-		super(Radiocraft.id("vertical_quad_loop"), 1.0D, 1.0D, 1.25D, 1.25D);
+		super(Radiocraft.id("vertical_quad_loop"), 0.0D, 0.0D, 1.25D, 1.25D);
 	}
 	@Override
 	public StaticAntenna<VerticalQuadLoopAntennaData> match(Level level, BlockPos pos) {

--- a/src/main/java/com/arrl/radiocraft/common/radio/antenna/types/WideBandReceiveAntennaType.java
+++ b/src/main/java/com/arrl/radiocraft/common/radio/antenna/types/WideBandReceiveAntennaType.java
@@ -12,8 +12,8 @@ import net.minecraft.world.level.block.Blocks;
 
 public class WideBandReceiveAntennaType extends NonDirectionalAntennaType<EmptyAntennaData> {
 
-    protected WideBandReceiveAntennaType(double receive, double transmit, double los, double skip) {
-        super(Radiocraft.id("wide_band_receive"), receive, transmit, los, skip);
+    protected WideBandReceiveAntennaType(double receiveGainDbi, double transmitGainDbi, double los, double skip) {
+        super(Radiocraft.id("wide_band_receive"), receiveGainDbi, transmitGainDbi, los, skip);
     }
 
     @Override
@@ -74,7 +74,7 @@ public class WideBandReceiveAntennaType extends NonDirectionalAntennaType<EmptyA
             case 40, 80 -> 0.2D;
             default -> 0.0D;
         };
-        return packet.getStrength() * f;
+        return getReceiveGainLinear() * packet.getStrength() * f;
     }
 
     @Override

--- a/src/main/java/com/arrl/radiocraft/common/radio/antenna/types/data/RubberDuckyAntennaData.java
+++ b/src/main/java/com/arrl/radiocraft/common/radio/antenna/types/data/RubberDuckyAntennaData.java
@@ -1,0 +1,34 @@
+package com.arrl.radiocraft.common.radio.antenna.types.data;
+
+import com.arrl.radiocraft.common.radio.antenna.AntennaData;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.nbt.CompoundTag;
+import org.jetbrains.annotations.UnknownNullability;
+
+public class RubberDuckyAntennaData extends AntennaData {
+
+    public RubberDuckyAntennaData(double length) {
+        this.length = length;
+    }
+
+    public double getLength() {
+        return length;
+    }
+
+    private static final String TAG_LENGTH = "length";
+
+    private double length;
+
+
+    @Override
+    public @UnknownNullability CompoundTag serializeNBT(HolderLookup.Provider provider) {
+        CompoundTag nbt = new CompoundTag();
+        nbt.putDouble(TAG_LENGTH, length);
+        return nbt;
+    }
+
+    @Override
+    public void deserializeNBT(HolderLookup.Provider provider, CompoundTag nbt) {
+        length = nbt.getDouble(TAG_LENGTH);
+    }
+}

--- a/src/main/java/com/arrl/radiocraft/common/radio/antenna/types/vhf/JPoleAntennaType.java
+++ b/src/main/java/com/arrl/radiocraft/common/radio/antenna/types/vhf/JPoleAntennaType.java
@@ -3,7 +3,6 @@ package com.arrl.radiocraft.common.radio.antenna.types.vhf;
 import com.arrl.radiocraft.Radiocraft;
 import com.arrl.radiocraft.api.antenna.IAntennaPacket;
 import com.arrl.radiocraft.common.init.RadiocraftBlocks;
-import com.arrl.radiocraft.common.radio.BandUtils;
 import com.arrl.radiocraft.common.radio.antenna.StaticAntenna;
 import com.arrl.radiocraft.common.radio.antenna.types.NonDirectionalAntennaType;
 import com.arrl.radiocraft.common.radio.antenna.types.data.EmptyAntennaData;
@@ -13,7 +12,7 @@ import net.minecraft.world.level.Level;
 public class JPoleAntennaType extends NonDirectionalAntennaType<EmptyAntennaData> {
 
     public JPoleAntennaType() {
-        super(Radiocraft.id("j_pole"), 1.0D, 1.0D, 1.0D, 0.0D);
+        super(Radiocraft.id("j_pole"), 0.0D, 0.0D, 1.0D, 0.0D);
     }
 
     @Override
@@ -22,9 +21,8 @@ public class JPoleAntennaType extends NonDirectionalAntennaType<EmptyAntennaData
     }
 
     @Override
-    public double getTransmitEfficiency(IAntennaPacket packet, EmptyAntennaData data, BlockPos destination, boolean isCW) {
-        double distance = Math.sqrt(packet.getSource().getAntennaPos().position().distSqr(destination)) / 1.3D;
-        return BandUtils.getBaseStrength(packet.getWavelength(), isCW ? distance / 1.5D : distance, 1.0F, 0.0F, packet.getLevel().isDay());
+    protected double modifyDistanceForTransmit(IAntennaPacket packet, EmptyAntennaData data, BlockPos destination, double distance) {
+        return distance / 1.3D;
     }
 
     @Override

--- a/src/main/java/com/arrl/radiocraft/common/radio/antenna/types/vhf/SlimJimAntennaType.java
+++ b/src/main/java/com/arrl/radiocraft/common/radio/antenna/types/vhf/SlimJimAntennaType.java
@@ -3,7 +3,6 @@ package com.arrl.radiocraft.common.radio.antenna.types.vhf;
 import com.arrl.radiocraft.Radiocraft;
 import com.arrl.radiocraft.api.antenna.IAntennaPacket;
 import com.arrl.radiocraft.common.init.RadiocraftBlocks;
-import com.arrl.radiocraft.common.radio.BandUtils;
 import com.arrl.radiocraft.common.radio.antenna.StaticAntenna;
 import com.arrl.radiocraft.common.radio.antenna.types.NonDirectionalAntennaType;
 import com.arrl.radiocraft.common.radio.antenna.types.data.EmptyAntennaData;
@@ -14,7 +13,7 @@ import net.minecraft.world.level.Level;
 public class SlimJimAntennaType extends NonDirectionalAntennaType<EmptyAntennaData> {
 
     public SlimJimAntennaType() {
-        super(Radiocraft.id("slim_jim"), 1.0D, 1.0D, 1.0D, 0.0D);
+        super(Radiocraft.id("slim_jim"), 0.0D, 0.0D, 1.0D, 0.0D);
     }
 
     @Override
@@ -28,13 +27,20 @@ public class SlimJimAntennaType extends NonDirectionalAntennaType<EmptyAntennaDa
         if(level.isThundering())
             return 0.0D;
 
-        double distance = Math.sqrt(packet.getSource().getAntennaPos().position().distSqr(destination)) / 1.2D;
-        return BandUtils.getBaseStrength(packet.getWavelength(), isCW ? distance / 1.5D : distance, 1.0F, 0.0F, level.isDay());
+        return super.getTransmitEfficiency(packet, data, destination, isCW);
     }
 
     @Override
     public double getReceiveEfficiency(IAntennaPacket packet, EmptyAntennaData data, BlockPos pos) {
-        return packet.getLevel().isThundering() ? 0.0D : 1.0D;
+        if(packet.getLevel().isThundering())
+            return 0.0D;
+
+        return getReceiveGainLinear() * packet.getStrength();
+    }
+
+    @Override
+    protected double modifyDistanceForTransmit(IAntennaPacket packet, EmptyAntennaData data, BlockPos destination, double distance) {
+        return distance / 1.2D;
     }
 
     @Override

--- a/src/main/java/com/arrl/radiocraft/common/radio/antenna/types/vhf/YagiAntennaType.java
+++ b/src/main/java/com/arrl/radiocraft/common/radio/antenna/types/vhf/YagiAntennaType.java
@@ -3,7 +3,6 @@ package com.arrl.radiocraft.common.radio.antenna.types.vhf;
 import com.arrl.radiocraft.Radiocraft;
 import com.arrl.radiocraft.api.antenna.IAntennaPacket;
 import com.arrl.radiocraft.common.init.RadiocraftBlocks;
-import com.arrl.radiocraft.common.radio.BandUtils;
 import com.arrl.radiocraft.common.radio.antenna.StaticAntenna;
 import com.arrl.radiocraft.common.radio.antenna.types.DirectionalAntennaType;
 import com.arrl.radiocraft.common.radio.antenna.types.data.YagiAntennaData;
@@ -17,23 +16,12 @@ import net.minecraft.world.phys.Vec2;
 public class YagiAntennaType extends DirectionalAntennaType<YagiAntennaData> {
 
     public YagiAntennaType() {
-        super(Radiocraft.id("yagi"), 1.0D, 1.0D, 1.0D, 0.0D);
+        super(Radiocraft.id("yagi"), 0.0D, 0.0D, 1.0D, 0.0D);
     }
 
     @Override
     public StaticAntenna<YagiAntennaData> match(Level level, BlockPos pos) {
         return level.getBlockState(pos).is(RadiocraftBlocks.YAGI_ANTENNA.get()) ? new StaticAntenna<>(this, pos, level) : null;
-    }
-
-    @Override
-    public double getTransmitEfficiency(IAntennaPacket packet, YagiAntennaData data, BlockPos destination, boolean isCW) {
-        double distance = Math.sqrt(packet.getSource().getAntennaPos().position().distSqr(destination)) / 2.0D;
-        return BandUtils.getBaseStrength(packet.getWavelength(), isCW ? distance / 1.5D : distance, 1.0F, 0.0F, packet.getLevel().isDay());
-    }
-
-    @Override
-    public double getReceiveEfficiency(IAntennaPacket packet, YagiAntennaData data, BlockPos pos) {
-        return 1.0D;
     }
 
     @Override
@@ -47,6 +35,11 @@ public class YagiAntennaType extends DirectionalAntennaType<YagiAntennaData> {
             return Mth.lerp(f / 0.25D, 1.0D, 0.1D); // 100% performance on facing side, scaled linearly to 45 degree threshold.
         else
             return f * 0.1D; // 10% performance when on sides or rear.
+    }
+
+    @Override
+    protected double modifyDistanceForTransmit(IAntennaPacket packet, YagiAntennaData data, BlockPos destination, double distance) {
+        return distance / 2.0D;
     }
 
     @Override

--- a/src/main/java/com/arrl/radiocraft/common/radio/voice/handheld/PlayerRadio.java
+++ b/src/main/java/com/arrl/radiocraft/common/radio/voice/handheld/PlayerRadio.java
@@ -2,6 +2,7 @@ package com.arrl.radiocraft.common.radio.voice.handheld;
 
 import com.arrl.radiocraft.Radiocraft;
 import com.arrl.radiocraft.api.antenna.IAntenna;
+import com.arrl.radiocraft.api.antenna.IAntennaType;
 import com.arrl.radiocraft.api.blockentities.radio.IVoiceTransmitter;
 import com.arrl.radiocraft.api.capabilities.IVHFHandheldCapability;
 import com.arrl.radiocraft.common.capabilities.RadiocraftCapabilities;
@@ -9,9 +10,13 @@ import com.arrl.radiocraft.common.init.RadiocraftItems;
 import com.arrl.radiocraft.common.radio.BandUtils;
 import com.arrl.radiocraft.common.radio.IVoiceReceiver;
 import com.arrl.radiocraft.common.radio.antenna.AntennaCWPacket;
+import com.arrl.radiocraft.common.radio.antenna.AntennaData;
 import com.arrl.radiocraft.common.radio.antenna.AntennaNetwork;
 import com.arrl.radiocraft.common.radio.antenna.AntennaVoicePacket;
 import com.arrl.radiocraft.common.radio.antenna.networks.AntennaNetworkManager;
+import com.arrl.radiocraft.common.radio.antenna.types.QuarterWaveVerticalAntennaType;
+import com.arrl.radiocraft.common.radio.antenna.types.RubberDuckyAntennaType;
+import com.arrl.radiocraft.common.radio.antenna.types.data.RubberDuckyAntennaData;
 import com.arrl.radiocraft.common.radio.morse.CWBuffer;
 import com.arrl.radiocraft.common.radio.voice.RadiocraftVoicePlugin;
 import de.maxhenkel.voicechat.api.ServerLevel;
@@ -159,6 +164,16 @@ public class PlayerRadio implements IVoiceTransmitter, IVoiceReceiver, IAntenna 
     @Override
     public AntennaPos getAntennaPos() {
         return this.antennaPos.get();
+    }
+
+    @Override
+    public IAntennaType<? extends AntennaData> getType() {
+        return new RubberDuckyAntennaType();
+    }
+
+    @Override
+    public AntennaData getData() {
+        return new RubberDuckyAntennaData(0.1);
     }
 
     @Override


### PR DESCRIPTION
Yeah. There's a lot to unpack here.

  - Added `/antenna` admin command to dump all registered antenna networks and their members, aiding server-side debugging.
  - Registered the antenna_analyzer handheld item that inspects networks in-world and reports handheld antenna stats in dev environments.
  - Extended handheld radios to participate in VHF networks as true antennas, introducing the RubberDuckyAntennaType and its persisted data model to describe portable gain/SWR characteristics.
  - Refined antenna APIs to surface each antenna’s type and data and reworked non-directional gain math to convert dBi values to linear strengths, updating all antenna type constructors accordingly.
  - Expanded AntennaNetworkManager with helpers for aggregating antennas, enabling the new toolchain and diagnostics to survey HF/VHF membership.
