### PR TITLE
Adds callsign permissions system

### DIFF
--- a/src/main/java/com/arrl/radiocraft/RadiocraftServerConfig.java
+++ b/src/main/java/com/arrl/radiocraft/RadiocraftServerConfig.java
@@ -18,6 +18,8 @@ public class RadiocraftServerConfig {
 	public static final ModConfigSpec.ConfigValue<Double> HANDHELD_MAX_GAIN;
 	public static final ModConfigSpec.ConfigValue<Double> HANDHELD_MAX_MIC_GAIN;
 
+    public static final ModConfigSpec.ConfigValue<Boolean> CALLSIGN_PERMISSIONS_ENABLED;
+
 	public record BandConfig(int wavelength, ModConfigSpec.ConfigValue<Integer> losRange, ModConfigSpec.ConfigValue<Integer> minSkipDay, ModConfigSpec.ConfigValue<Integer> maxSkipDay, ModConfigSpec.ConfigValue<Integer> minSkipNight, ModConfigSpec.ConfigValue<Integer> maxSkipNight, ModConfigSpec.ConfigValue<Integer> minFrequency, ModConfigSpec.ConfigValue<Integer> maxFrequency) {
 		public Band getBand() {
 			return new Band(wavelength, losRange.get(), minSkipDay.get(), maxSkipDay.get(), minSkipNight.get(), maxSkipNight.get(), minFrequency.get(), maxFrequency.get());
@@ -59,6 +61,10 @@ public class RadiocraftServerConfig {
 		HANDHELD_MAX_GAIN = BUILDER.comment(" Maximum output gain").defineInRange("handheld_max_gain", 5.0, 1.0, 25.0);
 		HANDHELD_MAX_MIC_GAIN = BUILDER.comment(" Maximum microphone gain").defineInRange("handheld_max_mic_gain", 5.0, 1.0, 25.0);
 		BUILDER.pop();
+
+        BUILDER.push("Permissions");
+        CALLSIGN_PERMISSIONS_ENABLED = BUILDER.comment(" Require op for callsign configuration").define("callsign_permissions_enabled", true);
+        BUILDER.pop();
 
 		SPEC = BUILDER.build();
 	}

--- a/src/main/java/com/arrl/radiocraft/common/commands/CallsignCommands.java
+++ b/src/main/java/com/arrl/radiocraft/common/commands/CallsignCommands.java
@@ -1,6 +1,7 @@
 package com.arrl.radiocraft.common.commands;
 
 import com.arrl.radiocraft.Radiocraft;
+import com.arrl.radiocraft.RadiocraftServerConfig;
 import com.arrl.radiocraft.api.capabilities.BlockEntityCallsignData;
 import com.arrl.radiocraft.api.capabilities.LicenseClass;
 import com.arrl.radiocraft.api.capabilities.PlayerCallsignData;
@@ -18,6 +19,7 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.Level;
 import net.neoforged.neoforge.server.command.EnumArgument;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -175,6 +177,10 @@ public class CallsignCommands {
 			source.sendFailure(Component.translatable(Radiocraft.translationKey("commands", "callsign.reset.failure.multiple")));
 			return 0;
 		}
+        if (RadiocraftServerConfig.CALLSIGN_PERMISSIONS_ENABLED.get() && !isPrivileged(source.getPlayerOrException())) {
+            source.sendFailure(Component.translatable(Radiocraft.translationKey("commands", "callsign.reset.failure.permission")));
+            return 0;
+        }
 		final GameProfile targetProfile = getTarget(source, gameProfiles);
 		playerSavedData = getPlayerCallsignSavedData(source.getLevel());
 		playerSavedData.resetCallsign(targetProfile.getId());
@@ -189,6 +195,10 @@ public class CallsignCommands {
 			source.sendFailure(Component.translatable(Radiocraft.translationKey("commands", "callsign.set.failure.multiple")));
 			return 0;
 		}
+        if (RadiocraftServerConfig.CALLSIGN_PERMISSIONS_ENABLED.get() && !isPrivileged(source.getPlayerOrException())) {
+            source.sendFailure(Component.translatable(Radiocraft.translationKey("commands", "callsign.set.failure.permission")));
+            return 0;
+        }
 		final GameProfile targetProfile = getTarget(source, gameProfiles);
 		playerSavedData = getPlayerCallsignSavedData(source.getLevel());
 		playerSavedData.setCallsignData(targetProfile.getId(), new PlayerCallsignData(targetProfile.getId().toString(), targetProfile.getName(), callsign, licenseClass));
@@ -204,4 +214,12 @@ public class CallsignCommands {
 				source.getPlayerOrException().getGameProfile() :
 				gameProfiles.stream().findFirst().get();
 	}
+
+    private static boolean isPrivileged(@NotNull ServerPlayer player) {
+        if (player.serverLevel().getServer().isSingleplayer()) {
+            return true;
+        }
+        // https://minecraft.fandom.com/wiki/Permission_level
+        return player.hasPermissions(3);
+    }
 }

--- a/src/main/java/com/arrl/radiocraft/datagen/RadiocraftLanguageProvider.java
+++ b/src/main/java/com/arrl/radiocraft/datagen/RadiocraftLanguageProvider.java
@@ -76,6 +76,7 @@ public class RadiocraftLanguageProvider extends LanguageProvider {
 			provider.add(Radiocraft.translationKey("commands", "callsign.get.success"), "%s's callsign is %s of license class %s.");
 			provider.add(Radiocraft.translationKey("commands", "callsign.get.failure"), "%s does not have a callsign.");
 			provider.add(Radiocraft.translationKey("commands", "callsign.get.failure.multiple"), "Cannot get the callsign of multiple targets at once.");
+            provider.add(Radiocraft.translationKey("commands", "callsign.get.failure.permission"), "You must have permission to change callsigns to use this command.");
 			provider.add(Radiocraft.translationKey("commands", "callsign.reset.success"), "%s's callsign has been reset.");
 			provider.add(Radiocraft.translationKey("commands", "callsign.reset.failure.multiple"), "Cannot reset the callsign of multiple targets at once.");
 			provider.add(Radiocraft.translationKey("commands", "callsign.set.success"), "%s's callsign has been set to %s and license class %s.");


### PR DESCRIPTION
Operator permissions (specifically, permission level 3) is required to set a callsign if enabled in the configuration (true by default)