### PR TITLE
Update build behavior, upload build artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,4 +34,3 @@ jobs:
             path: build/libs/*.jar
             if-no-files-found: warn
             retention-days: 14
-            compression-value: 0


### PR DESCRIPTION
* Builds now run on push; previously pull requests had double builds which was unnecessary.
* Artifacts are now uploaded as a final step for testing purposes
* Datagen is run for more complete testing